### PR TITLE
Miriad antpos fix

### DIFF
--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -53,7 +53,7 @@ class Miriad(UVData):
                               'telescope_name': 'telescop',
                               'instrument': 'telescop',
                               'Nants_telescope': 'nants',
-                              'antenna_positions': 'antpos',  # take deltas
+            #                  'antenna_positions': 'antpos',  # take deltas
                               }
         for item in miriad_header_data:
             if isinstance(uv[miriad_header_data[item]], str):
@@ -62,6 +62,10 @@ class Miriad(UVData):
                 header_value = uv[miriad_header_data[item]]
             setattr(self, item, header_value)
 
+	try:
+            self.antenna_positions=uv['antpos']
+        except(KeyError):
+            self.antenna_positions=np.zeros((3, self.Nants_telescope)).T
         latitude = uv['latitud']  # in units of radians
         longitude = uv['longitu']
         try:

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -52,8 +52,7 @@ class Miriad(UVData):
                               # as the same
                               'telescope_name': 'telescop',
                               'instrument': 'telescop',
-                              'Nants_telescope': 'nants',
-            #                  'antenna_positions': 'antpos',  # take deltas
+                              'Nants_telescope': 'nants'
                               }
         for item in miriad_header_data:
             if isinstance(uv[miriad_header_data[item]], str):

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -66,6 +66,7 @@ class Miriad(UVData):
             self.antenna_positions=uv['antpos']
         except(KeyError):
             self.antenna_positions=np.zeros((3, self.Nants_telescope)).T
+
         latitude = uv['latitud']  # in units of radians
         longitude = uv['longitu']
         try:


### PR DESCRIPTION
This branch contains a few small changes to ensure Miriad files missing the antpos table can still be read in. This happens with MIRIAD files generated from FHD save files, since save files are missing antenna positions. A future update to FHD should include the antenna positions in save files, but for now pyuvdata will spoof antenna positions as zero.