### PR TITLE
Added a select function (issue #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For simple installation, the latest stable version is available via pip using ``
 
 ### Optionally install the development version
 For the development version, clone the repository using
-```git clone https://github.com/HERA-Team/pyuvdata/releases/latest```
+```git clone https://github.com/HERA-Team/pyuvdata.git```
 
 Navigate into the directory and run ```python setup.py install```.
 Note that this will automatically install all dependencies. If you use anaconda or another package manager you might prefer not to do this.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. pyuvdata documentation master file, created by
-   make_index.py on 2017-02-15
+   make_index.py on 2017-03-13
 
 pyuvdata
 ========
@@ -108,7 +108,7 @@ Optionally install the development version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For the development version, clone the repository using
-``git clone https://github.com/HERA-Team/pyuvdata/releases/latest``
+``git clone https://github.com/HERA-Team/pyuvdata.git``
 
 Navigate into the directory and run ``python setup.py install``. Note
 that this will automatically install all dependencies. If you use

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -85,3 +85,44 @@ Making a simple waterfall plot::
   bl_ind = np.where(UV.baseline_array == bl)[0]  # Indices corresponding to baseline
   plt.imshow(np.abs(UV.data_array[bl_ind, 0, :, 0]))  # Amplitude waterfall for 0th spectral window and 0th polarization
   plt.show()
+
+Example 4
+---------
+Selecting data: The select method lets you select specific antennas, frequencies,
+times or polarizations to keep in the object while removing others.
+
+a) Select 3 antennas to keep using the antenna number.
+****************
+::
+
+  from pyuvdata import UVData
+  import numpy as np
+  UV = UVData()
+  filename = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
+  UV.read_uvfits(filename)
+  # print all the antennas numbers with data in the original file
+  print(np.unique(UV.ant_1_array.tolist() + UV.ant_2_array.tolist()))
+  UV.select(antenna_nums=[0, 11, 20])
+  # print all the antennas numbers with data after the select
+  print(np.unique(UV.ant_1_array.tolist() + UV.ant_2_array.tolist()))
+
+b) Select 3 antennas to keep using the antenna names, also select 5 frequencies to keep.
+****************
+::
+
+  from pyuvdata import UVData
+  import numpy as np
+  UV = UVData()
+  filename = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
+  UV.read_uvfits(filename)
+  # print all the antenna names with data in the original file
+  unique_ants = np.unique(UV.ant_1_array.tolist() + UV.ant_2_array.tolist())
+  print([UV.antenna_names[np.where(UV.antenna_numbers==a)[0][0]] for a in unique_ants])
+  # print all the frequencies in the original file
+  print(UV.freq_array)
+  UV.select(antenna_names=['N02', 'E09', 'W06'], frequencies=UV.freq_array[0,0:4])
+  # print all the antenna names with data after the select
+  unique_ants = np.unique(UV.ant_1_array.tolist() + UV.ant_2_array.tolist())
+  print([UV.antenna_names[np.where(UV.antenna_numbers==a)[0][0]] for a in unique_ants])
+  # print all the frequencies after the select
+  print(UV.freq_array)

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -438,6 +438,19 @@ class Miriad(UVData):
             else:
                 raise ValueError('File exists: skipping')
 
+        freq_spacing = self.freq_array[0, 1:] - self.freq_array[0, :-1]
+        if not np.isclose(np.min(freq_spacing), np.max(freq_spacing),
+                          rtol=self._freq_array.tols[0], atol=self._freq_array.tols[1]):
+            raise ValueError('The frequencies are not evenly spaced (probably '
+                             'because of a select operation). The miriad format '
+                             'does not support unevenly spaced frequencies.')
+        if not np.isclose(np.max(freq_spacing), self.channel_width,
+                          rtol=self._freq_array.tols[0], atol=self._freq_array.tols[1]):
+            raise ValueError('The frequencies are separated by more than their '
+                             'channel width (probably because of a select operation). '
+                             'The miriad format does not support frequencies '
+                             'that are spaced by more than their channel width.')
+
         uv = a.miriad.UV(filepath, status='new')
 
         # initialize header variables

--- a/pyuvdata/tests/__init__.py
+++ b/pyuvdata/tests/__init__.py
@@ -1,9 +1,9 @@
 """Setup testing environment, define useful testing functions."""
 import os
 import warnings
-import collections
 import sys
 from pyuvdata.data import DATA_PATH
+import pyuvdata.utils as uvutils
 
 
 def setup_package():
@@ -15,14 +15,6 @@ def setup_package():
 
 
 # Functions that are useful for testing:
-def get_iterable(x):
-    """Helper function for checkWarnings."""
-    if isinstance(x, collections.Iterable):
-        return x
-    else:
-        return (x,)
-
-
 def clearWarnings():
     """Quick code to make warnings reproducible."""
     for name, mod in list(sys.modules.items()):
@@ -51,8 +43,8 @@ def checkWarnings(func, func_args=[], func_kwargs={},
         message = ['Required Antenna frame keyword', 'telescope_location is not set']
         nwarnings = 2
 
-    category = get_iterable(category)
-    message = get_iterable(message)
+    category = uvutils.get_iterable(category)
+    message = uvutils.get_iterable(message)
 
     clearWarnings()
     with warnings.catch_warnings(record=True) as w:

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -217,7 +217,7 @@ def test_select_blts():
     uv_object.select_blts(blt_inds)
 
 
-def test_antennas():
+def test_select_antennas():
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -215,13 +215,25 @@ def test_select_blts():
     blt_inds = np.random.choice(uv_object.Nblts, uv_object.Nblts / 10, replace=False)
 
     uv_object.select_blts(blt_inds)
+    nt.assert_equal(len(blt_inds), uv_object.Nblts)
+
+    uv_object2 = UVData()
+    uvtest.checkWarnings(uv_object2.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    uv_object2.select(blt_inds=blt_inds)
+    nt.assert_equal(uv_object, uv_object2)
+
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    nt.assert_raises(ValueError, uv_object.select_blts, np.arange(-10, -5))
+    nt.assert_raises(ValueError, uv_object.select_blts, np.arange(uv_object.Nblts + 1, uv_object.Nblts + 10))
 
 
 def test_select_antennas():
     uv_object = UVData()
-    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
+    testfile = os.path.join(DATA_PATH, 'zen.2456865.60537.xy.uvcRREAA')
+    uvtest.checkWarnings(uv_object.read_miriad, [testfile],
+                         known_warning='miriad')
     unique_ants = np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
     ants_to_keep = np.random.choice(unique_ants, len(unique_ants) / 2, replace=False)
 
@@ -232,6 +244,16 @@ def test_select_antennas():
         nt.assert_true(ant in uv_object.ant_1_array or ant in uv_object.ant_2_array)
     for ant in np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist()):
         nt.assert_true(ant in ants_to_keep)
+
+    uv_object2 = UVData()
+    uvtest.checkWarnings(uv_object2.read_miriad, [testfile],
+                         known_warning='miriad')
+    uv_object2.select(antennas=ants_to_keep)
+    nt.assert_equal(uv_object, uv_object2)
+
+    uvtest.checkWarnings(uv_object.read_miriad, [testfile],
+                         known_warning='miriad')
+    nt.assert_raises(ValueError, uv_object.select_antennas, np.max(unique_ants) + np.arange(1, 3))
 
 
 def test_select_times():
@@ -250,6 +272,16 @@ def test_select_times():
     for t in np.unique(uv_object.time_array):
         nt.assert_true(t in times_to_keep)
 
+    uv_object2 = UVData()
+    uvtest.checkWarnings(uv_object2.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    uv_object2.select(times=times_to_keep)
+    nt.assert_equal(uv_object, uv_object2)
+
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    nt.assert_raises(ValueError, uv_object.select_times, [np.min(unique_times) - uv_object.integration_time])
+
 
 def test_select_frequencies():
     uv_object = UVData()
@@ -265,6 +297,16 @@ def test_select_frequencies():
     for t in np.unique(uv_object.freq_array):
         nt.assert_true(t in freqs_to_keep)
 
+    uv_object2 = UVData()
+    uvtest.checkWarnings(uv_object2.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    uv_object2.select(frequencies=freqs_to_keep)
+    nt.assert_equal(uv_object, uv_object2)
+
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    nt.assert_raises(ValueError, uv_object.select_frequencies, [np.max(uv_object.freq_array) + uv_object.channel_width])
+
 
 def test_select_polarizations():
     uv_object = UVData()
@@ -272,7 +314,7 @@ def test_select_polarizations():
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
     pols_to_keep = np.random.choice(uv_object.polarization_array, uv_object.Npols / 2, replace=False)
-    print('keeping {n} polarizations'.format(n=len(pols_to_keep)))
+    pols_dropped = [p for p in uv_object.polarization_array if p not in pols_to_keep]
     uv_object.select_polarizations(pols_to_keep)
 
     nt.assert_equal(len(pols_to_keep), uv_object.Npols)
@@ -281,19 +323,37 @@ def test_select_polarizations():
     for t in np.unique(uv_object.polarization_array):
         nt.assert_true(t in pols_to_keep)
 
+    uv_object2 = UVData()
+    uvtest.checkWarnings(uv_object2.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    uv_object2.select(polarizations=pols_to_keep)
+    nt.assert_equal(uv_object, uv_object2)
+
+    nt.assert_raises(ValueError, uv_object.select_polarizations, pols_dropped)
+
 
 def test_select():
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
+    old_history = uv_object.history
+    # have to be careful with selecting on blt_inds before antennas or times
+    # because removing blt_inds can remove entire times or antennas.
+    # With this test file, times are particularly sensitive. So test in 2 stages,
+    # one with everything but blts, and one with just blts & antennas for coverage.
     unique_ants = np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
-    ants_to_keep = np.random.choice(unique_ants, len(unique_ants) / 2, replace=False)
+    ants_to_keep = np.random.choice(unique_ants, len(unique_ants) - 1, replace=False)
 
     freqs_to_keep = np.random.choice(uv_object.freq_array[0, :], uv_object.Nfreqs / 10, replace=False)
-    uv_object.select_frequencies(freqs_to_keep)
 
-    uv_object.select(antennas=ants_to_keep, frequencies=freqs_to_keep)
+    unique_times = np.unique(uv_object.time_array)
+    times_to_keep = np.random.choice(unique_times, uv_object.Ntimes / 2, replace=False)
+
+    pols_to_keep = np.random.choice(uv_object.polarization_array, uv_object.Npols / 2, replace=False)
+
+    uv_object.select(antennas=ants_to_keep, frequencies=freqs_to_keep,
+                     times=times_to_keep, polarizations=pols_to_keep)
 
     nt.assert_equal(len(ants_to_keep), uv_object.Nants_data)
     for ant in ants_to_keep:
@@ -306,3 +366,19 @@ def test_select():
         nt.assert_true(t in uv_object.freq_array)
     for t in np.unique(uv_object.freq_array):
         nt.assert_true(t in freqs_to_keep)
+
+    nt.assert_equal(old_history + '  Downselected to specific antennas, '
+                    'frequencies, times, polarizations using pyuvdata.',
+                    uv_object.history)
+
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    old_history = uv_object.history
+
+    blt_inds = np.random.choice(uv_object.Nblts, int(uv_object.Nblts * 0.9), replace=False)
+
+    uv_object.select(blt_inds=blt_inds, antennas=ants_to_keep)
+
+    nt.assert_equal(old_history + '  Downselected to specific baseline-times, '
+                    'antennas using pyuvdata.',
+                    uv_object.history)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -280,3 +280,29 @@ def test_select_polarizations():
         nt.assert_true(t in uv_object.polarization_array)
     for t in np.unique(uv_object.polarization_array):
         nt.assert_true(t in pols_to_keep)
+
+
+def test_select():
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    unique_ants = np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
+    ants_to_keep = np.random.choice(unique_ants, len(unique_ants) / 2, replace=False)
+
+    freqs_to_keep = np.random.choice(uv_object.freq_array[0, :], uv_object.Nfreqs / 10, replace=False)
+    uv_object.select_frequencies(freqs_to_keep)
+
+    uv_object.select(antennas=ants_to_keep, frequencies=freqs_to_keep)
+
+    nt.assert_equal(len(ants_to_keep), uv_object.Nants_data)
+    for ant in ants_to_keep:
+        nt.assert_true(ant in uv_object.ant_1_array or ant in uv_object.ant_2_array)
+    for ant in np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist()):
+        nt.assert_true(ant in ants_to_keep)
+
+    nt.assert_equal(len(freqs_to_keep), uv_object.Nfreqs)
+    for t in freqs_to_keep:
+        nt.assert_true(t in uv_object.freq_array)
+    for t in np.unique(uv_object.freq_array):
+        nt.assert_true(t in freqs_to_keep)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -205,3 +205,33 @@ def test_phase_unphaseHERA():
     nt.assert_equal(UV_raw, UV_phase)
     del(UV_phase)
     del(UV_raw)
+
+
+def test_select_blts():
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    blt_inds = np.random.choice(uv_object.Nblts, uv_object.Nblts / 10, replace=False)
+
+    uv_object.select_blts(blt_inds)
+
+
+def test_select_times():
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    unique_times = np.unique(uv_object.time_array)
+    times_to_keep = np.random.choice(unique_times, uv_object.Ntimes / 2, replace=False)
+    for t in times_to_keep:
+        if t not in uv_object.time_array:
+            raise ValueError('chosen time not in time_array!')
+
+    uv_object.select_times(times_to_keep)
+
+    nt.assert_equal(len(times_to_keep), uv_object.Ntimes)
+    for t in times_to_keep:
+        nt.assert_true(t in uv_object.time_array)
+    for t in np.unique(uv_object.time_array):
+        nt.assert_true(t in times_to_keep)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -324,7 +324,6 @@ def test_select_frequencies():
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
     old_history = uv_object.history
-    start_ind = np.random.randint(0, int(uv_object.Nfreqs * .9))
     freqs_to_keep = uv_object.freq_array[0, np.arange(12, 22)]
 
     uv_object2 = copy.deepcopy(uv_object)
@@ -416,7 +415,6 @@ def test_select():
     unique_ants = np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
     ants_to_keep = np.array([11, 6, 20, 26, 2, 27, 3, 7, 14])
 
-    start_ind = np.random.randint(0, int(uv_object.Nfreqs * .9))
     freqs_to_keep = uv_object.freq_array[0, np.arange(31, 39)]
 
     unique_times = np.unique(uv_object.time_array)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -213,7 +213,23 @@ def test_select_blts():
     uvtest.checkWarnings(uv_object.read_miriad, [testfile],
                          known_warning='miriad')
     old_history = uv_object.history
-    blt_inds = np.random.choice(uv_object.Nblts, uv_object.Nblts / 10, replace=False)
+    blt_inds = np.array([172, 182, 132, 227, 144, 44, 16, 104, 385, 134, 326, 140, 116,
+                         218, 178, 391, 111, 276, 274, 308, 38, 64, 317, 76, 239, 246,
+                         34, 39, 83, 184, 208, 60, 374, 295, 118, 337, 261, 21, 375,
+                         396, 355, 187, 95, 122, 186, 113, 260, 264, 156, 13, 228, 291,
+                         302, 72, 137, 216, 299, 341, 207, 256, 223, 250, 268, 147, 73,
+                         32, 142, 383, 221, 203, 258, 286, 324, 265, 170, 236, 8, 275,
+                         304, 117, 29, 167, 15, 388, 171, 82, 322, 248, 160, 85, 66,
+                         46, 272, 328, 323, 152, 200, 119, 359, 23, 363, 56, 219, 257,
+                         11, 307, 336, 289, 136, 98, 37, 163, 158, 80, 125, 40, 298,
+                         75, 320, 74, 57, 346, 121, 129, 332, 238, 93, 18, 330, 339,
+                         381, 234, 176, 22, 379, 199, 266, 100, 90, 292, 205, 58, 222,
+                         350, 109, 273, 191, 368, 88, 101, 65, 155, 2, 296, 306, 398,
+                         369, 378, 254, 67, 249, 102, 348, 392, 20, 28, 169, 262, 269,
+                         287, 86, 300, 143, 177, 42, 290, 284, 123, 189, 175, 97, 340,
+                         242, 342, 331, 282, 235, 344, 63, 115, 78, 30, 226, 157, 133,
+                         71, 35, 212, 333])
+
     selected_data = uv_object.data_array[np.sort(blt_inds), :, :, :]
 
     uv_object2 = copy.deepcopy(uv_object)
@@ -235,7 +251,7 @@ def test_select_antennas():
                          message='Telescope EVLA is not')
     old_history = uv_object.history
     unique_ants = np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
-    ants_to_keep = np.random.choice(unique_ants, len(unique_ants) / 2, replace=False)
+    ants_to_keep = np.array([0, 19, 11, 24, 3, 23, 1, 20, 21])
 
     blts_select = [(a1 in ants_to_keep) & (a2 in ants_to_keep) for (a1, a2) in
                    zip(uv_object.ant_1_array, uv_object.ant_2_array)]
@@ -281,7 +297,7 @@ def test_select_times():
                          message='Telescope EVLA is not')
     old_history = uv_object.history
     unique_times = np.unique(uv_object.time_array)
-    times_to_keep = np.random.choice(unique_times, uv_object.Ntimes / 2, replace=False)
+    times_to_keep = unique_times[[0, 3, 5, 6, 7, 10, 14]]
 
     Nblts_selected = np.sum([t in times_to_keep for t in uv_object.time_array])
 
@@ -309,7 +325,7 @@ def test_select_frequencies():
                          message='Telescope EVLA is not')
     old_history = uv_object.history
     start_ind = np.random.randint(0, int(uv_object.Nfreqs * .9))
-    freqs_to_keep = uv_object.freq_array[0, start_ind:start_ind + (uv_object.Nfreqs / 10)]
+    freqs_to_keep = uv_object.freq_array[0, np.arange(12, 22)]
 
     uv_object2 = copy.deepcopy(uv_object)
     uv_object2.select(frequencies=freqs_to_keep)
@@ -350,8 +366,7 @@ def test_select_polarizations():
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
     old_history = uv_object.history
-    pols_to_keep = np.random.choice(uv_object.polarization_array, uv_object.Npols / 2, replace=False)
-    pols_dropped = [p for p in uv_object.polarization_array if p not in pols_to_keep]
+    pols_to_keep = [-1, -2]
 
     uv_object2 = copy.deepcopy(uv_object)
     uv_object2.select(polarizations=pols_to_keep)
@@ -366,7 +381,7 @@ def test_select_polarizations():
                     'using pyuvdata.', uv_object2.history)
 
     # check for errors associated with polarizations not included in data
-    nt.assert_raises(ValueError, uv_object2.select, polarizations=pols_dropped)
+    nt.assert_raises(ValueError, uv_object2.select, polarizations=[-3, -4])
 
     # check for warnings and errors associated with unevenly spaced polarizations
     status = uvtest.checkWarnings(uv_object.select, [], {'polarizations': uv_object.polarization_array[[0, 1, 3]]},

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -249,3 +249,34 @@ def test_select_times():
         nt.assert_true(t in uv_object.time_array)
     for t in np.unique(uv_object.time_array):
         nt.assert_true(t in times_to_keep)
+
+
+def test_select_frequencies():
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    freqs_to_keep = np.random.choice(uv_object.freq_array[0, :], uv_object.Nfreqs / 10, replace=False)
+    uv_object.select_frequencies(freqs_to_keep)
+
+    nt.assert_equal(len(freqs_to_keep), uv_object.Nfreqs)
+    for t in freqs_to_keep:
+        nt.assert_true(t in uv_object.freq_array)
+    for t in np.unique(uv_object.freq_array):
+        nt.assert_true(t in freqs_to_keep)
+
+
+def test_select_polarizations():
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    pols_to_keep = np.random.choice(uv_object.polarization_array, uv_object.Npols / 2, replace=False)
+    print('keeping {n} polarizations'.format(n=len(pols_to_keep)))
+    uv_object.select_polarizations(pols_to_keep)
+
+    nt.assert_equal(len(pols_to_keep), uv_object.Npols)
+    for t in pols_to_keep:
+        nt.assert_true(t in uv_object.polarization_array)
+    for t in np.unique(uv_object.polarization_array):
+        nt.assert_true(t in pols_to_keep)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -217,6 +217,23 @@ def test_select_blts():
     uv_object.select_blts(blt_inds)
 
 
+def test_antennas():
+    uv_object = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    unique_ants = np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist())
+    ants_to_keep = np.random.choice(unique_ants, len(unique_ants) / 2, replace=False)
+
+    uv_object.select_antennas(ants_to_keep)
+
+    nt.assert_equal(len(ants_to_keep), uv_object.Nants_data)
+    for ant in ants_to_keep:
+        nt.assert_true(ant in uv_object.ant_1_array or ant in uv_object.ant_2_array)
+    for ant in np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist()):
+        nt.assert_true(ant in ants_to_keep)
+
+
 def test_select_times():
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
@@ -224,9 +241,6 @@ def test_select_times():
                          message='Telescope EVLA is not')
     unique_times = np.unique(uv_object.time_array)
     times_to_keep = np.random.choice(unique_times, uv_object.Ntimes / 2, replace=False)
-    for t in times_to_keep:
-        if t not in uv_object.time_array:
-            raise ValueError('chosen time not in time_array!')
 
     uv_object.select_times(times_to_keep)
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -216,15 +216,14 @@ def test_select_blts():
     blt_inds = np.random.choice(uv_object.Nblts, uv_object.Nblts / 10, replace=False)
     selected_data = uv_object.data_array[np.sort(blt_inds), :, :, :]
 
-    uv_object.select(blt_inds=blt_inds)
-    nt.assert_equal(len(blt_inds), uv_object.Nblts)
+    uv_object2 = copy.deepcopy(uv_object)
+    uv_object2.select(blt_inds=blt_inds)
+    nt.assert_equal(len(blt_inds), uv_object2.Nblts)
     nt.assert_equal(old_history + '  Downselected to specific baseline-times '
-                    'using pyuvdata.', uv_object.history)
-    nt.assert_true(np.all(selected_data == uv_object.data_array))
+                    'using pyuvdata.', uv_object2.history)
+    nt.assert_true(np.all(selected_data == uv_object2.data_array))
 
     # check for errors associated with out of bounds indices
-    uvtest.checkWarnings(uv_object.read_miriad, [testfile],
-                         known_warning='miriad')
     nt.assert_raises(ValueError, uv_object.select, blt_inds=np.arange(-10, -5))
     nt.assert_raises(ValueError, uv_object.select, blt_inds=np.arange(uv_object.Nblts + 1, uv_object.Nblts + 10))
 
@@ -242,32 +241,30 @@ def test_select_antennas():
                    zip(uv_object.ant_1_array, uv_object.ant_2_array)]
     Nblts_selected = np.sum(blts_select)
 
-    uv_object.select(antenna_nums=ants_to_keep)
+    uv_object2 = copy.deepcopy(uv_object)
+    uv_object2.select(antenna_nums=ants_to_keep)
 
-    nt.assert_equal(len(ants_to_keep), uv_object.Nants_data)
-    nt.assert_equal(Nblts_selected, uv_object.Nblts)
+    nt.assert_equal(len(ants_to_keep), uv_object2.Nants_data)
+    nt.assert_equal(Nblts_selected, uv_object2.Nblts)
     for ant in ants_to_keep:
-        nt.assert_true(ant in uv_object.ant_1_array or ant in uv_object.ant_2_array)
-    for ant in np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist()):
+        nt.assert_true(ant in uv_object2.ant_1_array or ant in uv_object2.ant_2_array)
+    for ant in np.unique(uv_object2.ant_1_array.tolist() + uv_object2.ant_2_array.tolist()):
         nt.assert_true(ant in ants_to_keep)
 
     nt.assert_equal(old_history + '  Downselected to specific antennas '
-                    'using pyuvdata.', uv_object.history)
+                    'using pyuvdata.', uv_object2.history)
 
     # now test using antenna_names to specify antennas to keep
-    uv_object2 = UVData()
-    uvtest.checkWarnings(uv_object2.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
-
+    uv_object3 = copy.deepcopy(uv_object)
     ants_to_keep = np.array(sorted(list(ants_to_keep)))
     ant_names = []
     for a in ants_to_keep:
-        ind = np.where(uv_object2.antenna_numbers == a)[0][0]
-        ant_names.append(uv_object2.antenna_names[ind])
+        ind = np.where(uv_object3.antenna_numbers == a)[0][0]
+        ant_names.append(uv_object3.antenna_names[ind])
 
-    uv_object2.select(antenna_names=ant_names)
+    uv_object3.select(antenna_names=ant_names)
 
-    nt.assert_equal(uv_object, uv_object2)
+    nt.assert_equal(uv_object2, uv_object3)
 
     # check for errors associated with antennas not included in data, bad names or providing numbers and names
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
@@ -288,21 +285,20 @@ def test_select_times():
 
     Nblts_selected = np.sum([t in times_to_keep for t in uv_object.time_array])
 
-    uv_object.select(times=times_to_keep)
+    uv_object2 = copy.deepcopy(uv_object)
+    uv_object2.select(times=times_to_keep)
 
-    nt.assert_equal(len(times_to_keep), uv_object.Ntimes)
-    nt.assert_equal(Nblts_selected, uv_object.Nblts)
+    nt.assert_equal(len(times_to_keep), uv_object2.Ntimes)
+    nt.assert_equal(Nblts_selected, uv_object2.Nblts)
     for t in times_to_keep:
-        nt.assert_true(t in uv_object.time_array)
-    for t in np.unique(uv_object.time_array):
+        nt.assert_true(t in uv_object2.time_array)
+    for t in np.unique(uv_object2.time_array):
         nt.assert_true(t in times_to_keep)
 
     nt.assert_equal(old_history + '  Downselected to specific times '
-                    'using pyuvdata.', uv_object.history)
+                    'using pyuvdata.', uv_object2.history)
 
     # check for errors associated with times not included in data
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
     nt.assert_raises(ValueError, uv_object.select, times=[np.min(unique_times) - uv_object.integration_time])
 
 
@@ -315,38 +311,37 @@ def test_select_frequencies():
     start_ind = np.random.randint(0, int(uv_object.Nfreqs * .9))
     freqs_to_keep = uv_object.freq_array[0, start_ind:start_ind + (uv_object.Nfreqs / 10)]
 
-    uv_object.select(frequencies=freqs_to_keep)
+    uv_object2 = copy.deepcopy(uv_object)
+    uv_object2.select(frequencies=freqs_to_keep)
 
-    nt.assert_equal(len(freqs_to_keep), uv_object.Nfreqs)
+    nt.assert_equal(len(freqs_to_keep), uv_object2.Nfreqs)
     for f in freqs_to_keep:
-        nt.assert_true(f in uv_object.freq_array)
-    for f in np.unique(uv_object.freq_array):
+        nt.assert_true(f in uv_object2.freq_array)
+    for f in np.unique(uv_object2.freq_array):
         nt.assert_true(f in freqs_to_keep)
 
     nt.assert_equal(old_history + '  Downselected to specific frequencies '
-                    'using pyuvdata.', uv_object.history)
+                    'using pyuvdata.', uv_object2.history)
 
     # check for errors associated with frequencies not included in data
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
     nt.assert_raises(ValueError, uv_object.select, frequencies=[np.max(uv_object.freq_array) + uv_object.channel_width])
 
     # check for warnings and errors associated with unevenly spaced or non-contiguous frequencies
-    status = uvtest.checkWarnings(uv_object.select, [], {'frequencies': uv_object.freq_array[0, [0, 5, 6]]},
+    uv_object2 = copy.deepcopy(uv_object)
+    status = uvtest.checkWarnings(uv_object2.select, [], {'frequencies': uv_object2.freq_array[0, [0, 5, 6]]},
                                   message='Selected frequencies are not evenly spaced')
     nt.assert_true(status)
     write_file_uvfits = os.path.join(DATA_PATH, 'test/select_test.uvfits')
     write_file_miriad = os.path.join(DATA_PATH, 'test/select_test.uv')
-    nt.assert_raises(ValueError, uv_object.write_uvfits, write_file_uvfits)
-    nt.assert_raises(ValueError, uv_object.write_miriad, write_file_miriad)
+    nt.assert_raises(ValueError, uv_object2.write_uvfits, write_file_uvfits)
+    nt.assert_raises(ValueError, uv_object2.write_miriad, write_file_miriad)
 
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
-    status = uvtest.checkWarnings(uv_object.select, [], {'frequencies': uv_object.freq_array[0, [0, 2, 4]]},
+    uv_object2 = copy.deepcopy(uv_object)
+    status = uvtest.checkWarnings(uv_object2.select, [], {'frequencies': uv_object2.freq_array[0, [0, 2, 4]]},
                                   message='Selected frequencies are not contiguous')
     nt.assert_true(status)
-    nt.assert_raises(ValueError, uv_object.write_uvfits, write_file_uvfits)
-    nt.assert_raises(ValueError, uv_object.write_miriad, write_file_miriad)
+    nt.assert_raises(ValueError, uv_object2.write_uvfits, write_file_uvfits)
+    nt.assert_raises(ValueError, uv_object2.write_miriad, write_file_miriad)
 
 
 def test_select_polarizations():
@@ -358,23 +353,22 @@ def test_select_polarizations():
     pols_to_keep = np.random.choice(uv_object.polarization_array, uv_object.Npols / 2, replace=False)
     pols_dropped = [p for p in uv_object.polarization_array if p not in pols_to_keep]
 
-    uv_object.select(polarizations=pols_to_keep)
+    uv_object2 = copy.deepcopy(uv_object)
+    uv_object2.select(polarizations=pols_to_keep)
 
-    nt.assert_equal(len(pols_to_keep), uv_object.Npols)
+    nt.assert_equal(len(pols_to_keep), uv_object2.Npols)
     for p in pols_to_keep:
-        nt.assert_true(p in uv_object.polarization_array)
-    for p in np.unique(uv_object.polarization_array):
+        nt.assert_true(p in uv_object2.polarization_array)
+    for p in np.unique(uv_object2.polarization_array):
         nt.assert_true(p in pols_to_keep)
 
     nt.assert_equal(old_history + '  Downselected to specific polarizations '
-                    'using pyuvdata.', uv_object.history)
+                    'using pyuvdata.', uv_object2.history)
 
     # check for errors associated with polarizations not included in data
-    nt.assert_raises(ValueError, uv_object.select, polarizations=pols_dropped)
+    nt.assert_raises(ValueError, uv_object2.select, polarizations=pols_dropped)
 
     # check for warnings and errors associated with unevenly spaced polarizations
-    uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
-                         message='Telescope EVLA is not')
     status = uvtest.checkWarnings(uv_object.select, [], {'polarizations': uv_object.polarization_array[[0, 1, 3]]},
                                   message='Selected polarization values are not evenly spaced')
     nt.assert_true(status)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -220,6 +220,7 @@ def test_select_blts():
     nt.assert_equal(old_history + '  Downselected to specific baseline-times '
                     'using pyuvdata.', uv_object.history)
 
+    # check for errors associated with out of bounds indices
     uvtest.checkWarnings(uv_object.read_miriad, [testfile],
                          known_warning='miriad')
     nt.assert_raises(ValueError, uv_object.select, blt_inds=np.arange(-10, -5))
@@ -261,6 +262,7 @@ def test_select_antennas():
 
     nt.assert_equal(uv_object, uv_object2)
 
+    # check for errors associated with antennas not included in data, bad names or providing numbers and names
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
     nt.assert_raises(ValueError, uv_object.select, antenna_nums=np.max(unique_ants) + np.arange(1, 3))
@@ -288,6 +290,7 @@ def test_select_times():
     nt.assert_equal(old_history + '  Downselected to specific times '
                     'using pyuvdata.', uv_object.history)
 
+    # check for errors associated with times not included in data
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
     nt.assert_raises(ValueError, uv_object.select, times=[np.min(unique_times) - uv_object.integration_time])
@@ -313,10 +316,12 @@ def test_select_frequencies():
     nt.assert_equal(old_history + '  Downselected to specific frequencies '
                     'using pyuvdata.', uv_object.history)
 
+    # check for errors associated with frequencies not included in data
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
     nt.assert_raises(ValueError, uv_object.select, frequencies=[np.max(uv_object.freq_array) + uv_object.channel_width])
 
+    # check for warnings and errors associated with unevenly spaced or non-contiguous frequencies
     status = uvtest.checkWarnings(uv_object.select, [], {'frequencies': uv_object.freq_array[0, [0, 5, 6]]},
                                   message='Selected frequencies are not evenly spaced')
     nt.assert_true(status)
@@ -354,11 +359,12 @@ def test_select_polarizations():
     nt.assert_equal(old_history + '  Downselected to specific polarizations '
                     'using pyuvdata.', uv_object.history)
 
+    # check for errors associated with polarizations not included in data
     nt.assert_raises(ValueError, uv_object.select, polarizations=pols_dropped)
 
+    # check for warnings and errors associated with unevenly spaced polarizations
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
-    print(uv_object.polarization_array)
     status = uvtest.checkWarnings(uv_object.select, [], {'polarizations': uv_object.polarization_array[[0, 1, 3]]},
                                   message='Selected polarization values are not evenly spaced')
     nt.assert_true(status)
@@ -367,7 +373,7 @@ def test_select_polarizations():
 
 
 def test_select():
-    # now test selecting along multiple axes at once
+    # now test selecting along all axes at once
     uv_object = UVData()
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(uv_object.read_uvfits, [testfile],
@@ -392,10 +398,16 @@ def test_select():
 
     for ant in np.unique(uv_object.ant_1_array.tolist() + uv_object.ant_2_array.tolist()):
         nt.assert_true(ant in ants_to_keep)
+    nt.assert_equal(len(freqs_to_keep), uv_object.Nfreqs)
+    for f in freqs_to_keep:
+        nt.assert_true(f in uv_object.freq_array)
     for f in np.unique(uv_object.freq_array):
         nt.assert_true(f in freqs_to_keep)
     for t in np.unique(uv_object.time_array):
         nt.assert_true(t in times_to_keep)
+    nt.assert_equal(len(pols_to_keep), uv_object.Npols)
+    for p in pols_to_keep:
+        nt.assert_true(p in uv_object.polarization_array)
     for p in np.unique(uv_object.polarization_array):
         nt.assert_true(p in pols_to_keep)
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1,5 +1,6 @@
 """Commonly used utility functions."""
 import numpy as np
+import collections
 
 # parameters for transforming between xyz & lat/lon/alt
 gps_b = 6356752.31424518
@@ -57,3 +58,11 @@ def XYZ_from_LatLonAlt(latitude, longitude, altitude):
     xyz[2] = ((gps_b**2 / gps_a**2 * gps_N + altitude) * np.sin(latitude))
 
     return xyz
+
+
+def get_iterable(x):
+    """Helper function to ensure iterability."""
+    if isinstance(x, collections.Iterable):
+        return x
+    else:
+        return (x,)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -714,6 +714,8 @@ class UVData(UVBase):
 
         if blt_inds is not None:
 
+            if len(blt_inds) == 0:
+                raise ValueError('No baseline-times were found that match criteria')
             if max(blt_inds) >= self.Nblts:
                 raise ValueError('blt_inds contains indices that are too large')
             if min(blt_inds) < 0:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -620,7 +620,8 @@ class UVData(UVBase):
         del(obs)
         self.set_phased()
 
-    def select_blts(self, blt_inds, run_check=True, run_check_acceptability=True):
+    def select_blts(self, blt_inds, run_check=True, run_check_acceptability=True,
+                    update_history=True):
         if max(blt_inds) >= self.Nblts:
             raise ValueError('blt_inds contains indices that are too large')
         if min(blt_inds) < 0:
@@ -646,6 +647,9 @@ class UVData(UVBase):
             self.zenith_ra = self.zenith_ra[blt_inds]
             self.zenith_dec = self.zenith_dec[blt_inds]
 
+        if update_history:
+            self.history = self.history + '  Downselected to specific baseline-times using pyuvdata.'
+
         # check if object is self-consistent
         if run_check:
             self.check(run_check_acceptability=run_check_acceptability)
@@ -661,8 +665,14 @@ class UVData(UVBase):
                 inds2 = np.append(inds2, list(wh2))
             else:
                 raise ValueError('Antenna {a} is not present in the ant_1_array or ant_2_array'.format(a=ant))
+
         blt_inds = np.array(list(set(inds1).intersection(inds2)), dtype=np.int)
-        self.select_blts(blt_inds, run_check=run_check, run_check_acceptability=run_check_acceptability)
+
+        self.history = self.history + '  Downselected to specific antennas using pyuvdata.'
+
+        self.select_blts(blt_inds, run_check=run_check,
+                         run_check_acceptability=run_check_acceptability,
+                         update_history=False)
 
     def select_times(self, times_to_keep, run_check=True, run_check_acceptability=True):
         blt_inds = np.zeros(0, dtype=np.int)
@@ -672,7 +682,11 @@ class UVData(UVBase):
             else:
                 raise ValueError('Time {t} is not present in the time_array'.format(t=jd))
 
-        self.select_blts(blt_inds, run_check=run_check, run_check_acceptability=run_check_acceptability)
+        self.history = self.history + '  Downselected to specific times using pyuvdata.'
+
+        self.select_blts(blt_inds, run_check=run_check,
+                         run_check_acceptability=run_check_acceptability,
+                         update_history=False)
 
     def select_frequencies(self, freqs_to_keep, run_check=True, run_check_acceptability=True):
         freq_inds = np.zeros(0, dtype=np.int)
@@ -690,6 +704,8 @@ class UVData(UVBase):
         self.data_array = self.data_array[:, :, freq_inds, :]
         self.flag_array = self.flag_array[:, :, freq_inds, :]
         self.nsample_array = self.nsample_array[:, :, freq_inds, :]
+
+        self.history = self.history + '  Downselected to specific frequencies using pyuvdata.'
 
         # check if object is self-consistent
         if run_check:
@@ -709,6 +725,8 @@ class UVData(UVBase):
         self.data_array = self.data_array[:, :, :, pol_inds]
         self.flag_array = self.flag_array[:, :, :, pol_inds]
         self.nsample_array = self.nsample_array[:, :, :, pol_inds]
+
+        self.history = self.history + '  Downselected to specific polarizations using pyuvdata.'
 
         # check if object is self-consistent
         if run_check:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -654,11 +654,11 @@ class UVData(UVBase):
         if run_check:
             self.check(run_check_acceptability=run_check_acceptability)
 
-    def select_antennas(self, antennas_to_keep, run_check=True, run_check_acceptability=True,
+    def select_antennas(self, antennas, run_check=True, run_check_acceptability=True,
                         update_history=True):
         inds1 = np.zeros(0, dtype=np.int)
         inds2 = np.zeros(0, dtype=np.int)
-        for ant in antennas_to_keep:
+        for ant in antennas:
             if ant in self.ant_1_array or ant in self.ant_2_array:
                 wh1 = np.where(self.ant_1_array == ant)[0]
                 wh2 = np.where(self.ant_2_array == ant)[0]
@@ -676,10 +676,10 @@ class UVData(UVBase):
                          run_check_acceptability=run_check_acceptability,
                          update_history=False)
 
-    def select_times(self, times_to_keep, run_check=True, run_check_acceptability=True,
+    def select_times(self, times, run_check=True, run_check_acceptability=True,
                      update_history=True):
         blt_inds = np.zeros(0, dtype=np.int)
-        for jd in times_to_keep:
+        for jd in times:
             if jd in self.time_array:
                 blt_inds = np.append(blt_inds, np.where(self.time_array == jd)[0])
             else:
@@ -692,12 +692,12 @@ class UVData(UVBase):
                          run_check_acceptability=run_check_acceptability,
                          update_history=False)
 
-    def select_frequencies(self, freqs_to_keep, run_check=True, run_check_acceptability=True,
+    def select_frequencies(self, frequencies, run_check=True, run_check_acceptability=True,
                            update_history=True):
         freq_inds = np.zeros(0, dtype=np.int)
         # this works because we only allow one SPW. This will have to be reworked when we support more.
         freq_arr_use = self.freq_array[0, :]
-        for f in freqs_to_keep:
+        for f in frequencies:
             if f in freq_arr_use:
                 freq_inds = np.append(freq_inds, np.where(freq_arr_use == f)[0])
             else:
@@ -717,10 +717,10 @@ class UVData(UVBase):
         if run_check:
             self.check(run_check_acceptability=run_check_acceptability)
 
-    def select_polarizations(self, pols_to_keep, run_check=True, run_check_acceptability=True,
+    def select_polarizations(self, polarizations, run_check=True, run_check_acceptability=True,
                              update_history=True):
         pol_inds = np.zeros(0, dtype=np.int)
-        for p in pols_to_keep:
+        for p in polarizations:
             if p in self.polarization_array:
                 pol_inds = np.append(pol_inds, np.where(self.polarization_array == p)[0])
             else:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -9,6 +9,7 @@ import ephem
 from uvbase import UVBase
 import parameter as uvp
 import telescopes as uvtel
+import utils as uvutils
 
 
 class UVData(UVBase):
@@ -657,6 +658,7 @@ class UVData(UVBase):
 
         # test for blt_inds presence before adding inds from antennas & times
         if blt_inds is not None:
+            blt_inds = uvutils.get_iterable(blt_inds)
             history_update_string += 'baseline-times'
             n_selects += 1
 
@@ -664,6 +666,7 @@ class UVData(UVBase):
             if antenna_nums is not None:
                 raise ValueError('Only one of antenna_nums and antenna_names can be provided.')
 
+            antenna_names = uvutils.get_iterable(antenna_names)
             antenna_nums = []
             for s in antenna_names:
                 if s not in self.antenna_names:
@@ -671,6 +674,7 @@ class UVData(UVBase):
                 antenna_nums.append(self.antenna_numbers[np.where(np.array(self.antenna_names) == s)[0]])
 
         if antenna_nums is not None:
+            antenna_nums = uvutils.get_iterable(antenna_nums)
             if n_selects > 0:
                 history_update_string += ', antennas'
             else:
@@ -694,6 +698,7 @@ class UVData(UVBase):
                 blt_inds = ant_blt_inds
 
         if times is not None:
+            times = uvutils.get_iterable(times)
             if n_selects > 0:
                 history_update_string += ', times'
             else:
@@ -742,6 +747,7 @@ class UVData(UVBase):
                 self.zenith_dec = self.zenith_dec[blt_inds]
 
         if frequencies is not None:
+            frequencies = uvutils.get_iterable(frequencies)
             if n_selects > 0:
                 history_update_string += ', frequencies'
             else:
@@ -775,6 +781,7 @@ class UVData(UVBase):
             self.nsample_array = self.nsample_array[:, :, freq_inds, :]
 
         if polarizations is not None:
+            polarizations = uvutils.get_iterable(polarizations)
             if n_selects > 0:
                 history_update_string += ', polarizations'
             else:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -659,8 +659,7 @@ class UVData(UVBase):
                 inds2 = np.append(inds2, list(wh2))
             else:
                 raise ValueError('Antenna {a} is not present in the ant_1_array or ant_2_array'.format(a=ant))
-        blt_inds = list(set(inds1).intersection(inds2))
-
+        blt_inds = np.array(list(set(inds1).intersection(inds2)), dtype=np.int)
         self.select_blts(blt_inds, run_check=run_check, run_check_acceptability=run_check_acceptability)
 
     def select_times(self, times_to_keep, run_check=True, run_check_acceptability=True):

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -620,161 +620,78 @@ class UVData(UVBase):
         del(obs)
         self.set_phased()
 
-    def select_blts(self, blt_inds, run_check=True, run_check_acceptability=True,
-                    update_history=True):
-        if max(blt_inds) >= self.Nblts:
-            raise ValueError('blt_inds contains indices that are too large')
-        if min(blt_inds) < 0:
-            raise ValueError('blt_inds contains indices that are negative')
+    def select(self, antenna_nums=None, antenna_names=None, frequencies=None,
+               times=None, polarizations=None, blt_inds=None, run_check=True,
+               run_check_acceptability=True):
+        """
+        Select specific antennas, frequencies, times and polarizations to keep
+        in the object while discarding others.
 
-        blt_inds = list(sorted(set(list(blt_inds))))
-        self.Nblts = len(blt_inds)
-        self.baseline_array = self.baseline_array[blt_inds]
-        self.time_array = self.time_array[blt_inds]
-        self.lst_array = self.lst_array[blt_inds]
-        self.data_array = self.data_array[blt_inds, :, :, :]
-        self.flag_array = self.flag_array[blt_inds, :, :, :]
-        self.nsample_array = self.nsample_array[blt_inds, :, :, :]
-        self.uvw_array = self.uvw_array[blt_inds, :]
+        Also supports selecting specific baseline-time indices to keep while
+        discarding others, but this is not commonly used. The history attribute
+        on the object will be updated to identify the operations performed.
 
-        self.ant_1_array = self.ant_1_array[blt_inds]
-        self.ant_2_array = self.ant_2_array[blt_inds]
-        self.Nants_data = int(len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist())))
-
-        self.Ntimes = len(np.unique(self.time_array))
-
-        if self.phase_type == 'drift':
-            self.zenith_ra = self.zenith_ra[blt_inds]
-            self.zenith_dec = self.zenith_dec[blt_inds]
-
-        if update_history:
-            self.history = self.history + '  Downselected to specific baseline-times using pyuvdata.'
-
-        # check if object is self-consistent
-        if run_check:
-            self.check(run_check_acceptability=run_check_acceptability)
-
-    def select_antennas(self, antennas, run_check=True, run_check_acceptability=True,
-                        update_history=True):
-        inds1 = np.zeros(0, dtype=np.int)
-        inds2 = np.zeros(0, dtype=np.int)
-        for ant in antennas:
-            if ant in self.ant_1_array or ant in self.ant_2_array:
-                wh1 = np.where(self.ant_1_array == ant)[0]
-                wh2 = np.where(self.ant_2_array == ant)[0]
-                inds1 = np.append(inds1, list(wh1))
-                inds2 = np.append(inds2, list(wh2))
-            else:
-                raise ValueError('Antenna {a} is not present in the ant_1_array or ant_2_array'.format(a=ant))
-
-        blt_inds = np.array(list(set(inds1).intersection(inds2)), dtype=np.int)
-
-        if update_history:
-            self.history = self.history + '  Downselected to specific antennas using pyuvdata.'
-
-        self.select_blts(blt_inds, run_check=run_check,
-                         run_check_acceptability=run_check_acceptability,
-                         update_history=False)
-
-    def select_times(self, times, run_check=True, run_check_acceptability=True,
-                     update_history=True):
-        blt_inds = np.zeros(0, dtype=np.int)
-        for jd in times:
-            if jd in self.time_array:
-                blt_inds = np.append(blt_inds, np.where(self.time_array == jd)[0])
-            else:
-                raise ValueError('Time {t} is not present in the time_array'.format(t=jd))
-
-        if update_history:
-            self.history = self.history + '  Downselected to specific times using pyuvdata.'
-
-        self.select_blts(blt_inds, run_check=run_check,
-                         run_check_acceptability=run_check_acceptability,
-                         update_history=False)
-
-    def select_frequencies(self, frequencies, run_check=True, run_check_acceptability=True,
-                           update_history=True):
-        freq_inds = np.zeros(0, dtype=np.int)
-        # this works because we only allow one SPW. This will have to be reworked when we support more.
-        freq_arr_use = self.freq_array[0, :]
-        for f in frequencies:
-            if f in freq_arr_use:
-                freq_inds = np.append(freq_inds, np.where(freq_arr_use == f)[0])
-            else:
-                raise ValueError('Frequency {f} is not present in the freq_array'.format(f=f))
-
-        freq_inds = list(sorted(set(list(freq_inds))))
-        self.Nfreqs = len(freq_inds)
-        self.freq_array = self.freq_array[:, freq_inds]
-        self.data_array = self.data_array[:, :, freq_inds, :]
-        self.flag_array = self.flag_array[:, :, freq_inds, :]
-        self.nsample_array = self.nsample_array[:, :, freq_inds, :]
-
-        if update_history:
-            self.history = self.history + '  Downselected to specific frequencies using pyuvdata.'
-
-        # check if object is self-consistent
-        if run_check:
-            self.check(run_check_acceptability=run_check_acceptability)
-
-    def select_polarizations(self, polarizations, run_check=True, run_check_acceptability=True,
-                             update_history=True):
-        pol_inds = np.zeros(0, dtype=np.int)
-        for p in polarizations:
-            if p in self.polarization_array:
-                pol_inds = np.append(pol_inds, np.where(self.polarization_array == p)[0])
-            else:
-                raise ValueError('Polarization {p} is not present in the polarization_array'.format(p=p))
-
-        pol_inds = list(sorted(set(list(pol_inds))))
-        self.Npols = len(pol_inds)
-        self.polarization_array = self.polarization_array[pol_inds]
-        self.data_array = self.data_array[:, :, :, pol_inds]
-        self.flag_array = self.flag_array[:, :, :, pol_inds]
-        self.nsample_array = self.nsample_array[:, :, :, pol_inds]
-
-        if update_history:
-            self.history = self.history + '  Downselected to specific polarizations using pyuvdata.'
-
-        # check if object is self-consistent
-        if run_check:
-            self.check(run_check_acceptability=run_check_acceptability)
-
-    def select(self, antennas=None, blt_inds=None, frequencies=None, times=None,
-               polarizations=None, run_check=True, run_check_acceptability=True,
-               update_history=True):
+        Args:
+            antenna_nums: The antennas numbers to keep in the object (antenna
+                positions and names for the removed antennas will be retained).
+                This cannot be provided if antenna_names is also provided.
+            antenna_names: The antennas names to keep in the object (antenna
+                positions and names for the removed antennas will be retained).
+                This cannot be provided if antenna_nums is also provided.
+            frequencies: The frequencies to keep in the object.
+            times: The times to keep in the object.
+            polarizations: The polarizations to keep in the object.
+            blt_inds: The baseline-time indices to keep in the object. This is
+                not commonly used.
+            run_check: Option to check for the existence and proper shapes of
+                required parameters after downselecting data on this object. Default is True.
+            run_check_acceptability: Option to check acceptable range of the values of
+                required parameters after  downselecting data on this object. Default is True.
+        """
         # build up history string as we go
         history_update_string = '  Downselected to specific '
         n_selects = 0
 
-        # need to run the select on blt_inds first, because those will change
-        # after selects on antennas or times
+        # Antennas, times and blt_inds all need to be combined into a set of
+        # blts indices to keep.
+
+        # test for blt_inds presence before adding inds from antennas & times
         if blt_inds is not None:
             history_update_string += 'baseline-times'
             n_selects += 1
-            self.select_blts(blt_inds, run_check=run_check,
-                             run_check_acceptability=run_check_acceptability,
-                             update_history=False)
 
-        if antennas is not None:
+        if antenna_names is not None:
+            if antenna_nums is not None:
+                raise ValueError('Only one of antenna_nums and antenna_names can be provided.')
+
+            antenna_nums = []
+            for s in antenna_names:
+                if s not in self.antenna_names:
+                    raise ValueError('Antenna name {a} is not present in the antenna_names array'.format(a=s))
+                antenna_nums.append(self.antenna_numbers[np.where(np.array(self.antenna_names) == s)[0]])
+
+        if antenna_nums is not None:
             if n_selects > 0:
                 history_update_string += ', antennas'
             else:
                 history_update_string += 'antennas'
             n_selects += 1
-            self.select_antennas(antennas, run_check=run_check,
-                                 run_check_acceptability=run_check_acceptability,
-                                 update_history=False)
+            inds1 = np.zeros(0, dtype=np.int)
+            inds2 = np.zeros(0, dtype=np.int)
+            for ant in antenna_nums:
+                if ant in self.ant_1_array or ant in self.ant_2_array:
+                    wh1 = np.where(self.ant_1_array == ant)[0]
+                    wh2 = np.where(self.ant_2_array == ant)[0]
+                    inds1 = np.append(inds1, list(wh1))
+                    inds2 = np.append(inds2, list(wh2))
+                else:
+                    raise ValueError('Antenna number {a} is not present in the ant_1_array or ant_2_array'.format(a=ant))
 
-        if frequencies is not None:
-            if n_selects > 0:
-                history_update_string += ', frequencies'
+            ant_blt_inds = np.array(list(set(inds1).intersection(inds2)), dtype=np.int)
+            if blt_inds is not None:
+                blt_inds = np.array(list(set(blt_inds).intersection(ant_blt_inds)), dtype=np.int)
             else:
-                history_update_string += 'frequencies'
-            n_selects += 1
-            self.select_frequencies(frequencies, run_check=run_check,
-                                    run_check_acceptability=run_check_acceptability,
-                                    update_history=False)
+                blt_inds = ant_blt_inds
 
         if times is not None:
             if n_selects > 0:
@@ -782,9 +699,78 @@ class UVData(UVBase):
             else:
                 history_update_string += 'times'
             n_selects += 1
-            self.select_times(times, run_check=run_check,
-                              run_check_acceptability=run_check_acceptability,
-                              update_history=False)
+
+            time_blt_inds = np.zeros(0, dtype=np.int)
+            for jd in times:
+                if jd in self.time_array:
+                    time_blt_inds = np.append(time_blt_inds, np.where(self.time_array == jd)[0])
+                else:
+                    raise ValueError('Time {t} is not present in the time_array'.format(t=jd))
+
+            if blt_inds is not None:
+                blt_inds = np.array(list(set(blt_inds).intersection(time_blt_inds)), dtype=np.int)
+            else:
+                blt_inds = time_blt_inds
+
+        if blt_inds is not None:
+
+            if max(blt_inds) >= self.Nblts:
+                raise ValueError('blt_inds contains indices that are too large')
+            if min(blt_inds) < 0:
+                raise ValueError('blt_inds contains indices that are negative')
+
+            blt_inds = list(sorted(set(list(blt_inds))))
+            self.Nblts = len(blt_inds)
+            self.baseline_array = self.baseline_array[blt_inds]
+            self.time_array = self.time_array[blt_inds]
+            self.lst_array = self.lst_array[blt_inds]
+            self.data_array = self.data_array[blt_inds, :, :, :]
+            self.flag_array = self.flag_array[blt_inds, :, :, :]
+            self.nsample_array = self.nsample_array[blt_inds, :, :, :]
+            self.uvw_array = self.uvw_array[blt_inds, :]
+
+            self.ant_1_array = self.ant_1_array[blt_inds]
+            self.ant_2_array = self.ant_2_array[blt_inds]
+            self.Nants_data = int(len(set(self.ant_1_array.tolist() + self.ant_2_array.tolist())))
+
+            self.Ntimes = len(np.unique(self.time_array))
+
+            if self.phase_type == 'drift':
+                self.zenith_ra = self.zenith_ra[blt_inds]
+                self.zenith_dec = self.zenith_dec[blt_inds]
+
+        if frequencies is not None:
+            if n_selects > 0:
+                history_update_string += ', frequencies'
+            else:
+                history_update_string += 'frequencies'
+            n_selects += 1
+
+            freq_inds = np.zeros(0, dtype=np.int)
+            # this works because we only allow one SPW. This will have to be reworked when we support more.
+            freq_arr_use = self.freq_array[0, :]
+            for f in frequencies:
+                if f in freq_arr_use:
+                    freq_inds = np.append(freq_inds, np.where(freq_arr_use == f)[0])
+                else:
+                    raise ValueError('Frequency {f} is not present in the freq_array'.format(f=f))
+
+            freq_ind_separation = freq_inds[1:] - freq_inds[:-1]
+            if np.min(freq_ind_separation) < np.max(freq_ind_separation):
+                warnings.warn('Selected frequencies are not evenly spaced. This '
+                              'will make it impossible to write this data out to '
+                              'some file types')
+            elif np.max(freq_ind_separation) > 1:
+                warnings.warn('Selected frequencies are not contiguous. This '
+                              'will make it impossible to write this data out to '
+                              'some file types.')
+
+            freq_inds = list(sorted(set(list(freq_inds))))
+            self.Nfreqs = len(freq_inds)
+            self.freq_array = self.freq_array[:, freq_inds]
+            self.data_array = self.data_array[:, :, freq_inds, :]
+            self.flag_array = self.flag_array[:, :, freq_inds, :]
+            self.nsample_array = self.nsample_array[:, :, freq_inds, :]
 
         if polarizations is not None:
             if n_selects > 0:
@@ -792,13 +778,34 @@ class UVData(UVBase):
             else:
                 history_update_string += 'polarizations'
             n_selects += 1
-            self.select_polarizations(polarizations, run_check=run_check,
-                                      run_check_acceptability=run_check_acceptability,
-                                      update_history=False)
+
+            pol_inds = np.zeros(0, dtype=np.int)
+            for p in polarizations:
+                if p in self.polarization_array:
+                    pol_inds = np.append(pol_inds, np.where(self.polarization_array == p)[0])
+                else:
+                    raise ValueError('Polarization {p} is not present in the polarization_array'.format(p=p))
+
+            if len(pol_inds) > 2:
+                pol_ind_separation = pol_inds[1:] - pol_inds[:-1]
+                if np.min(pol_ind_separation) < np.max(pol_ind_separation):
+                    warnings.warn('Selected polarization values are not evenly spaced. This '
+                                  'will make it impossible to write this data out to '
+                                  'some file types')
+
+            pol_inds = list(sorted(set(list(pol_inds))))
+            self.Npols = len(pol_inds)
+            self.polarization_array = self.polarization_array[pol_inds]
+            self.data_array = self.data_array[:, :, :, pol_inds]
+            self.flag_array = self.flag_array[:, :, :, pol_inds]
+            self.nsample_array = self.nsample_array[:, :, :, pol_inds]
 
         history_update_string += ' using pyuvdata.'
-        if update_history:
-            self.history = self.history + history_update_string
+        self.history = self.history + history_update_string
+
+        # check if object is self-consistent
+        if run_check:
+            self.check(run_check_acceptability=run_check_acceptability)
 
     def _convert_from_filetype(self, other):
         for p in other:

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -331,6 +331,25 @@ class UVFITS(UVData):
                              'Set the phase_type to drift or phased to '
                              'reflect the phasing status of the data')
 
+        freq_spacing = self.freq_array[0, 1:] - self.freq_array[0, :-1]
+        if not np.isclose(np.min(freq_spacing), np.max(freq_spacing),
+                          rtol=self._freq_array.tols[0], atol=self._freq_array.tols[1]):
+            raise ValueError('The frequencies are not evenly spaced (probably '
+                             'because of a select operation). The uvfits format '
+                             'does not support unevenly spaced frequencies.')
+        if not np.isclose(np.max(freq_spacing), self.channel_width,
+                          rtol=self._freq_array.tols[0], atol=self._freq_array.tols[1]):
+            raise ValueError('The frequencies are separated by more than their '
+                             'channel width (probably because of a select operation). '
+                             'The uvfits format does not support frequencies '
+                             'that are spaced by more than their channel width.')
+        if self.Npols > 2:
+            pol_spacing = self.polarization_array[1:] - self.polarization_array[:-1]
+            if np.min(pol_spacing) < np.max(pol_spacing):
+                raise ValueError('The polarization values are not evenly spaced (probably '
+                                 'because of a select operation). The uvfits format '
+                                 'does not support unevenly spaced polarizations.')
+
         for p in self.extra():
             param = getattr(self, p)
             if param.name in self.uvfits_required_extra:


### PR DESCRIPTION
Includes options for selecting antennas (by name or by number), frequencies, times, polarizations and even specific baseline-times (the latter probably won't be widely used but is needed for some kinds of file matching desired in the future, see issue #111).

The function is fully covered by tests, has a doc string, and I've added some tutorial examples on selecting, although the examples don't cover all the possibilities.

There are warnings (and associated errors in the appropriate write functions) for selections of frequencies or polarizations that will break miriad or uvfits file formats. The errors in the write functions are also covered by the tests.