### PR TITLE
Add uvdata

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -145,6 +145,67 @@ c) Select a few antenna pairs to keep
 
 Example 5
 ---------
+Adding data (UVData): The __add__ method lets you combine UVData objects along
+the baseline-time, frequency, and/or polarization axis.
+
+a) Add frequencies.
+****************
+::
+
+  from pyuvdata import UVData
+  import numpy as np
+  import copy
+  uv1 = UVData()
+  filename = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
+  uv1.read_uvfits(filename)
+  uv2 = copy.deepcopy(uv1)
+  # Downselect frequencies to recombine
+  uv1.select(freq_chans=np.arange(0, 32))
+  uv2.select(freq_chans=np.arange(32, 64))
+  uv3 = uv1 + uv2
+  print(uv1.Nfreqs, uv2.Nfreqs, uv3.Nfreqs)
+
+b) Add times.
+****************
+::
+
+  from pyuvdata import UVData
+  import numpy as np
+  import copy
+  uv1 = UVData()
+  filename = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
+  uv1.read_uvfits(filename)
+  uv2 = copy.deepcopy(uv1)
+  # Downselect times to recombine
+  times = np.unique(uv1.time_array)
+  uv1.select(times=times[0:len(times) / 2])
+  uv2.select(times=times[len(times) / 2:])
+  uv3 = uv1 + uv2
+  print(uv1.Ntimes, uv2.Ntimes, uv3.Ntimes)
+  print(uv1.Nblts, uv2.Nblts, uv3.Nblts)
+
+c) Adding in place. The following two commands are equivalent, and act on uv1
+directly without creating a third uvdata object.
+****************
+::
+
+  uv1.__add__(uv2, inplace=True)
+  uv1 += uv2
+
+d) Reading multiple files. If any of the read methods are given a list of files
+(or list of lists in the case of read_fhd), each file will be read in succession
+and added to the previous.
+****************
+::
+
+  from pyuvdata import UVData
+  uv = UVData()
+  filenames = ['file1.uvfits', 'file2.uvfits', 'file3.uvfits']
+  uv.read_uvfits(filenames)
+
+
+Example 6
+---------
 Calibration files using UVCal.
 
 a) Reading a gain calibration file.
@@ -219,7 +280,7 @@ b) Writing a gain calibration file.
 
   cal.write_calfits('tutorial5b.fits')
 
-Example 6
+Example 7
 ---------
 Selecting data (UVCal): The select method lets you select specific antennas (by number or name),
 frequencies (in Hz or by channel number), times or polarizations

--- a/pyuvdata/tests/test_fhd.py
+++ b/pyuvdata/tests/test_fhd.py
@@ -4,6 +4,7 @@ import os
 from pyuvdata import UVData
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
+import numpy as np
 
 # set up FHD file list
 testdir = os.path.join(DATA_PATH, 'fhd_vis_data/')
@@ -63,3 +64,20 @@ def test_ReadFHD_model():
     nt.assert_equal(fhd_uv, uvfits_uv)
     del(fhd_uv)
     del(uvfits_uv)
+
+
+def test_multi_files():
+    """
+    Reading multiple files at once.
+    """
+    fhd_uv1 = UVData()
+    fhd_uv2 = UVData()
+    test1 = list(np.array(testfiles)[[0, 1, 2, 4, 6]])
+    test2 = list(np.array(testfiles)[[0, 2, 3, 5, 6]])
+    fhd_uv1.read_fhd([test1, test2])
+    fhd_uv2.read_fhd(testfiles)
+
+    nt.assert_equal(fhd_uv2.history + ' Combined data along polarization axis using'
+                    ' pyuvdata.', fhd_uv1.history)
+    fhd_uv1.history = fhd_uv2.history
+    nt.assert_equal(fhd_uv1, fhd_uv2)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -661,3 +661,16 @@ def test_reorder_pols():
     uvtest.checkWarnings(uv1.read_uvfits, [testfile], message='Telescope EVLA is not')
     uv2.reorder_pols()
     nt.assert_equal(uv1, uv2)
+
+
+def test_add():
+    uv_full = UVData()
+    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_full.read_uvfits, [testfile],
+                         message='Telescope EVLA is not')
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    uv1.select(freq_chans=np.arange(0, 32))
+    uv2.select(freq_chans=np.arange(32, 64))
+    uv1 += uv2
+    nt.assert_equal(uv1, uv_full)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -668,9 +668,19 @@ def test_add():
     testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
     uvtest.checkWarnings(uv_full.read_uvfits, [testfile],
                          message='Telescope EVLA is not')
+
+    # Add frequencies
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
     uv1.select(freq_chans=np.arange(0, 32))
     uv2.select(freq_chans=np.arange(32, 64))
+    uv1 += uv2
+    # nt.assert_equal(uv1, uv_full)
+
+    # Add polarizations
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    uv1.select(polarizations=uv1.polarization_array[0:2])
+    uv2.select(polarizations=uv2.polarization_array[2:4])
     uv1 += uv2
     nt.assert_equal(uv1, uv_full)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -757,13 +757,13 @@ def test_add():
     uv1.history = uv_full.history
     nt.assert_equal(uv1, uv_ref)
 
-    # Add in place
+    # Add without inplace
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
     times = np.unique(uv_full.time_array)
     uv1.select(times=times[0:len(times) / 2])
     uv2.select(times=times[len(times) / 2:])
-    uv1.__add__(uv2, in_place=True)
+    uv1 = uv1 + uv2
     nt.assert_equal(uv_full.history + '  Downselected to specific times'
                     ' using pyuvdata. Combined data along baseline-time axis using'
                     ' pyuvdata.', uv1.history)
@@ -782,14 +782,14 @@ def test_add():
     uv2 = copy.deepcopy(uv_full)
     uv1.select(freq_chans=[0])
     uv2.select(freq_chans=[3])
-    uvtest.checkWarnings(uv1.__add__, [uv2],
+    uvtest.checkWarnings(uv1.__iadd__, [uv2],
                          message='Combined frequencies are not contiguous')
 
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
     uv1.select(polarizations=uv1.polarization_array[0:2])
     uv2.select(polarizations=uv2.polarization_array[3])
-    uvtest.checkWarnings(uv1.__add__, [uv2],
+    uvtest.checkWarnings(uv1.__iadd__, [uv2],
                          message='Combined polarizations are not evenly spaced')
 
 
@@ -802,18 +802,18 @@ def test_break_add():
 
     # Wrong class
     uv1 = copy.deepcopy(uv_full)
-    nt.assert_raises(ValueError, uv1.__add__, np.zeros(5))
+    nt.assert_raises(ValueError, uv1.__iadd__, np.zeros(5))
 
     # One phased, one not
     uv2 = copy.deepcopy(uv_full)
     uv2.unphase_to_drift()
-    nt.assert_raises(ValueError, uv1.__add__, uv2)
+    nt.assert_raises(ValueError, uv1.__iadd__, uv2)
 
     # Different units
     uv2 = copy.deepcopy(uv_full)
     uv2.vis_units = "Jy"
-    nt.assert_raises(ValueError, uv1.__add__, uv2)
+    nt.assert_raises(ValueError, uv1.__iadd__, uv2)
 
     # Overlapping data
     uv2 = copy.deepcopy(uv_full)
-    nt.assert_raises(ValueError, uv1.__add__, uv2)
+    nt.assert_raises(ValueError, uv1.__iadd__, uv2)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -707,6 +707,21 @@ def test_add():
     uv1.history = uv_full.history
     nt.assert_equal(uv1, uv_full)
 
+    # Add baselines
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    ant_list = range(15)  # Roughly half the antennas in the data
+    ind1 = [i for i in range(uv1.Nblts) if uv1.ant_1_array[i] in ant_list]  # All blts where ant_1 is in list
+    ind2 = [i for i in range(uv1.Nblts) if uv1.ant_1_array[i] not in ant_list]
+    uv1.select(blt_inds=ind1)
+    uv2.select(blt_inds=ind2)
+    uv1 += uv2
+    nt.assert_equal(uv_full.history + '  Downselected to specific baseline-times'
+                    ' using pyuvdata. Combined data along baseline-time axis using'
+                    ' pyuvdata.', uv1.history)
+    uv1.history = uv_full.history
+    nt.assert_equal(uv1, uv_full)
+
     # Add multiple axes
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -792,6 +792,19 @@ def test_add():
     uvtest.checkWarnings(uv1.__iadd__, [uv2],
                          message='Combined polarizations are not evenly spaced')
 
+    # Combining histories
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    uv1.select(polarizations=uv1.polarization_array[0:2])
+    uv2.select(polarizations=uv2.polarization_array[2:4])
+    uv2.history += ' testing the history. AIPS WTSCAL = 1.0'
+    uv1 += uv2
+    nt.assert_equal(uv_full.history + '  Downselected to specific polarizations'
+                    ' using pyuvdata. Combined data along polarization axis using'
+                    ' pyuvdata. testing the history.', uv1.history)
+    uv1.history = uv_full.history
+    nt.assert_equal(uv1, uv_full)
+
 
 def test_break_add():
     # Test failure modes of add function

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -637,6 +637,33 @@ class UVData(UVBase):
         del(obs)
         self.set_phased()
 
+    def __add__(self, other, run_check=True, run_check_acceptability=True):
+        """
+        Combine two UVData objects. Objects can be added along frequency,
+        polarization, and/or baseline-time axis.
+
+        Args:
+            other: Another UVData object which will be added to self.
+            run_check: Option to check for the existence and proper shapes of
+                required parameters after combining objects. Default is True.
+            run_check_acceptability: Option to check acceptable range of the values of
+                required parameters after combining objects. Default is True.
+        """
+        # Check that both objects are UVData and valid
+        self.check(run_check_acceptability=False)
+        if not isinstance(other, self.__class__):
+            raise(ValueError('Only UVData objects can be added to a UVData object'))
+        other.check(run_check_acceptability=False)
+
+        # TODO Determine axes to combine
+        # TODO Check objects are compatible
+        # TODO Combine data
+        # TODO Update N parameters (e.g. Npol)
+        # TODO Check specific requirements (channel width vs spacing, uniform tint, etc)
+        # Check final object is self-consistent
+        if run_check:
+            self.check(run_check_acceptability=run_check_acceptability)
+
     def select(self, antenna_nums=None, antenna_names=None, ant_pairs_nums=None,
                frequencies=None, freq_chans=None,
                times=None, polarizations=None, blt_inds=None, run_check=True,

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -638,7 +638,7 @@ class UVData(UVBase):
         del(obs)
         self.set_phased()
 
-    def __add__(self, other, run_check=True, run_check_acceptability=True, in_place=False):
+    def __add__(self, other, run_check=True, run_check_acceptability=True, inplace=False):
         """
         Combine two UVData objects. Objects can be added along frequency,
         polarization, and/or baseline-time axis.
@@ -649,10 +649,10 @@ class UVData(UVBase):
                 required parameters after combining objects. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 required parameters after combining objects. Default is True.
-            in_place: Overwrite self as we go, otherwise create a third object
+            inplace: Overwrite self as we go, otherwise create a third object
                 as the sum of the two (default).
         """
-        if in_place:
+        if inplace:
             this = self
         else:
             this = copy.deepcopy(self)
@@ -818,7 +818,18 @@ class UVData(UVBase):
         if run_check:
             this.check(run_check_acceptability=run_check_acceptability)
 
-        return this
+        if not inplace:
+            return this
+
+    def __iadd__(self, other):
+        """
+        In place add.
+
+        Args:
+            other: Another UVData object which will be added to self.
+        """
+        self.__add__(other, inplace=True)
+        return self
 
     def select(self, antenna_nums=None, antenna_names=None, ant_pairs_nums=None,
                frequencies=None, freq_chans=None,

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -697,7 +697,7 @@ class UVData(UVBase):
                                      ' cannot be combined.'))
 
         temp = np.array([[i, b] for (i, b) in enumerate(other_blts)
-                                        if b not in this_blts]).T
+                         if b not in this_blts]).T
         if len(temp) > 0:
             bnew_inds = temp[0].astype(int)
             new_blts = temp[1]
@@ -754,7 +754,7 @@ class UVData(UVBase):
                                  this.data_array.shape[2], len(pnew_inds)))
             this.polarization_array = np.concatenate([this.polarization_array,
                                                       other.polarization_array[pnew_inds]])
-            order = np.argsort(this.polarization_array)
+            order = np.argsort(np.abs(this.polarization_array))
             this.polarization_array = this.polarization_array[order]
             this.data_array = np.concatenate([this.data_array, zero_pad], axis=3)[:, :, :, order]
             this.nsample_array = np.concatenate([this.nsample_array, zero_pad], axis=3)[:, :, :, order]
@@ -769,12 +769,12 @@ class UVData(UVBase):
         this.nsample_array[np.ix_(blt_s2o, [0], freq_s2o, pol_s2o)] = other.nsample_array
         this.flag_array[np.ix_(blt_s2o, [0], freq_s2o, pol_s2o)] = other.flag_array
 
-        # Update N parameters (e.g. Npol)
+        # Update N parameters (e.g. Npols)
         this.Ntimes = len(np.unique(this.time_array))
         this.Nbls = len(np.unique(this.baseline_array))
         this.Nblts = this.uvw_array.shape[0]
         this.Nfreqs = this.freq_array.shape[1]
-        this.Npol = this.polarization_array.shape[0]
+        this.Npols = this.polarization_array.shape[0]
         this.Nants_data = len(np.unique(this.ant_1_array.tolist() + this.ant_2_array.tolist()))
 
         # TODO update history

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -814,6 +814,22 @@ class UVData(UVBase):
             history_update_string += ' axis using pyuvdata.'
             this.history += history_update_string
 
+        other_hist_words = other.history.split(' ')
+        add_hist = ''
+        for i, word in enumerate(other_hist_words):
+            if word not in this.history:
+                add_hist += ' ' + word
+                keep_going = (i + 1 < len(other_hist_words))
+                while keep_going:
+                    if ((other_hist_words[i + 1] is ' ') or
+                        (other_hist_words[i + 1] not in this.history)):
+                        add_hist += ' ' + other_hist_words[i + 1]
+                        del(other_hist_words[i + 1])
+                        keep_going = (i + 1 < len(other_hist_words))
+                    else:
+                        keep_going = False
+        this.history += add_hist
+
         # Check final object is self-consistent
         if run_check:
             this.check(run_check_acceptability=run_check_acceptability)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -696,25 +696,23 @@ class UVData(UVBase):
                     raise(ValueError('These objects have overlapping data and'
                                      ' cannot be combined.'))
 
-        temp = np.array([[i, b] for (i, b) in enumerate(other_blts)
-                         if b not in this_blts]).T
+        temp = np.nonzero(~np.in1d(other_blts, this_blts))[0]
         if len(temp) > 0:
-            bnew_inds = temp[0].astype(int)
-            new_blts = temp[1]
+            bnew_inds = temp
+            new_blts = other_blts[temp]
         else:
             bnew_inds, new_blts = ([], [])
-        temp = np.array([[i, f] for (i, f) in enumerate(other.freq_array[0, :])
-                         if f not in this.freq_array]).T
+        temp = np.nonzero(~np.in1d(other.freq_array[0, :], this.freq_array[0, :]))[0]
         if len(temp) > 0:
-            fnew_inds = temp[0].astype(int)
-            new_freqs = temp[1]
+            fnew_inds = temp
+            new_freqs = other.freq_array[0, temp]
         else:
             fnew_inds, new_freqs = ([], [])
-        temp = np.array([[i, p] for (i, p) in enumerate(other.polarization_array)
-                         if p not in this.polarization_array]).T
+        temp = np.nonzero(~np.in1d(other.polarization_array,
+                                   this.polarization_array))[0]
         if len(temp) > 0:
-            pnew_inds = temp[0].astype(int)
-            new_pols = temp[1]
+            pnew_inds = temp
+            new_pols = other.polarization_array[temp]
         else:
             pnew_inds, new_pols = ([], [])
         # Pad out self to accommodate new data
@@ -762,12 +760,12 @@ class UVData(UVBase):
                                              axis=3).astype(np.bool)[:, :, :, order]
 
         # Now populate the data
-        pol_s2o = np.nonzero(np.in1d(this.polarization_array, other.polarization_array))[0]
-        freq_s2o = np.nonzero(np.in1d(this.freq_array[0, :], other.freq_array[0, :]))[0]
-        blt_s2o = np.nonzero(np.in1d(this_blts, other_blts))[0]
-        this.data_array[np.ix_(blt_s2o, [0], freq_s2o, pol_s2o)] = other.data_array
-        this.nsample_array[np.ix_(blt_s2o, [0], freq_s2o, pol_s2o)] = other.nsample_array
-        this.flag_array[np.ix_(blt_s2o, [0], freq_s2o, pol_s2o)] = other.flag_array
+        pol_t2o = np.nonzero(np.in1d(this.polarization_array, other.polarization_array))[0]
+        freq_t2o = np.nonzero(np.in1d(this.freq_array[0, :], other.freq_array[0, :]))[0]
+        blt_t2o = np.nonzero(np.in1d(this_blts, other_blts))[0]
+        this.data_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = other.data_array
+        this.nsample_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = other.nsample_array
+        this.flag_array[np.ix_(blt_t2o, [0], freq_t2o, pol_t2o)] = other.flag_array
 
         # Update N parameters (e.g. Npols)
         this.Ntimes = len(np.unique(this.time_array))

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1108,18 +1108,29 @@ class UVData(UVBase):
         Read in data from a uvfits file.
 
         Args:
-            filename: The uvfits file to read from.
+            filename: The uvfits file or list of files to read from.
             run_check: Option to check for the existence and proper shapes of
                 required parameters after reading in the file. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 required parameters after reading in the file. Default is True.
         """
         import uvfits
-        uvfits_obj = uvfits.UVFITS()
-        uvfits_obj.read_uvfits(filename, run_check=run_check,
-                               run_check_acceptability=run_check_acceptability)
-        self._convert_from_filetype(uvfits_obj)
-        del(uvfits_obj)
+        if isinstance(filename, (list, tuple)):
+            self.read_uvfits(filename[0], run_check=run_check,
+                             run_check_acceptability=run_check_acceptability)
+            if len(filename) > 1:
+                for f in filename[1:]:
+                    uv2 = UVData()
+                    uv2.read_uvfits(f, run_check=run_check,
+                                    run_check_acceptability=run_check_acceptability)
+                    self += uv2
+                del(uv2)
+        else:
+            uvfits_obj = uvfits.UVFITS()
+            uvfits_obj.read_uvfits(filename, run_check=run_check,
+                                   run_check_acceptability=run_check_acceptability)
+            self._convert_from_filetype(uvfits_obj)
+            del(uvfits_obj)
 
     def write_uvfits(self, filename, spoof_nonessential=False,
                      force_phase=False, run_check=True, run_check_acceptability=True):
@@ -1152,6 +1163,7 @@ class UVData(UVBase):
         Args:
             filelist: The list of FHD save files to read from. Must include at
                 least one polarization file, a params file and a flag file.
+                Can also be a list of lists to read multiple data sets.
             use_model: Option to read in the model visibilities rather than the
                 dirty visibilities. Default is False.
             run_check: Option to check for the existence and proper shapes of
@@ -1160,11 +1172,22 @@ class UVData(UVBase):
                 required parameters after reading in the file. Default is True.
         """
         import fhd
-        fhd_obj = fhd.FHD()
-        fhd_obj.read_fhd(filelist, use_model=use_model, run_check=run_check,
-                         run_check_acceptability=run_check_acceptability)
-        self._convert_from_filetype(fhd_obj)
-        del(fhd_obj)
+        if isinstance(filelist[0], (list, tuple)):
+            self.read_fhd(filelist[0], use_model=use_model, run_check=run_check,
+                          run_check_acceptability=run_check_acceptability)
+            if len(filelist) > 1:
+                for f in filelist[1:]:
+                    uv2 = UVData()
+                    uv2.read_fhd(f, use_model=use_model, run_check=run_check,
+                                 run_check_acceptability=run_check_acceptability)
+                    self += uv2
+                del(uv2)
+        else:
+            fhd_obj = fhd.FHD()
+            fhd_obj.read_fhd(filelist, use_model=use_model, run_check=run_check,
+                             run_check_acceptability=run_check_acceptability)
+            self._convert_from_filetype(fhd_obj)
+            del(fhd_obj)
 
     def read_miriad(self, filepath, correct_lat_lon=True, run_check=True,
                     run_check_acceptability=True, phase_type=None):
@@ -1172,20 +1195,35 @@ class UVData(UVBase):
         Read in data from a miriad file.
 
         Args:
-            filepath: The miriad file directory to read from.
+            filepath: The miriad file directory or list of directories to read from.
             run_check: Option to check for the existence and proper shapes of
                 required parameters after reading in the file. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 required parameters after reading in the file. Default is True.
         """
         import miriad
-        miriad_obj = miriad.Miriad()
-        miriad_obj.read_miriad(filepath, correct_lat_lon=correct_lat_lon,
-                               run_check=run_check,
-                               run_check_acceptability=run_check_acceptability,
-                               phase_type=phase_type)
-        self._convert_from_filetype(miriad_obj)
-        del(miriad_obj)
+        if isinstance(filepath, (list, tuple)):
+            self.read_miriad(filepath[0], correct_lat_lon=correct_lat_lon,
+                             run_check=run_check,
+                             run_check_acceptability=run_check_acceptability,
+                             phase_type=phase_type)
+            if len(filepath) > 1:
+                for f in filepath[1:]:
+                    uv2 = UVData()
+                    uv2.read_miriad(f, correct_lat_lon=correct_lat_lon,
+                                    run_check=run_check,
+                                    run_check_acceptability=run_check_acceptability,
+                                    phase_type=phase_type)
+                    self += uv2
+                del(uv2)
+        else:
+            miriad_obj = miriad.Miriad()
+            miriad_obj.read_miriad(filepath, correct_lat_lon=correct_lat_lon,
+                                   run_check=run_check,
+                                   run_check_acceptability=run_check_acceptability,
+                                   phase_type=phase_type)
+            self._convert_from_filetype(miriad_obj)
+            del(miriad_obj)
 
     def write_miriad(self, filepath, run_check=True, run_check_acceptability=True,
                      clobber=False, no_antnums=False):


### PR DESCRIPTION
This branch adds the ability to combine uvdata objects along baseline-time, polarization, or frequency axes (or combinations). It also allows for in place adding (`uv1 += uv2`), and allows for multiple file reads (which really just iterates through the list, adding objects as it goes).