### PR TITLE
Calfits backwards compatibility fixes

### DIFF
--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -1,6 +1,7 @@
 import astropy
 from astropy.io import fits
 import numpy as np
+import warnings
 from uvcal import UVCal
 import utils as uvutils
 

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -439,7 +439,20 @@ class CALFITS(UVCal):
             self.freq_array = uvutils.fits_gethduaxis(sechdu, 4, strict_fits=strict_fits)
             self.freq_array.shape = (self.Nspws,) + self.freq_array.shape
 
-            spw_array = uvutils.fits_gethduaxis(sechdu, 5, strict_fits=strict_fits)
+            # add this for backwards compatibility when the spw CRVAL wasn't recorded
+            try:
+                spw_array = uvutils.fits_gethduaxis(sechdu, 5, strict_fits=strict_fits)
+            except(KeyError):
+                if not strict_fits:
+                    warnings.warn('{file} appears to be an old calfits format '
+                                  'which does not fully conform to the FITS standard. '
+                                  'Setting default values now, set strict_fits=True '
+                                  'to error rather than warn on this problem, '
+                                  'rewrite this file with write_calfits to ensure '
+                                  'FITS compliance.'.format(file=filename))
+                    spw_array = np.array([0])
+                else:
+                    raise
             if not np.allclose(spw_array, self.spw_array):
                 raise ValueError('Spectral window values are different in FLAGS HDU than in primary HDU')
 
@@ -460,7 +473,19 @@ class CALFITS(UVCal):
             totqualhdu = F[hdunames['TOTQLTY']]
             self.total_quality_array = totqualhdu.data
 
-            spw_array = uvutils.fits_gethduaxis(totqualhdu, 4, strict_fits=strict_fits)
+            try:
+                spw_array = uvutils.fits_gethduaxis(totqualhdu, 4, strict_fits=strict_fits)
+            except(KeyError):
+                if not strict_fits:
+                    warnings.warn('{file} appears to be an old calfits format '
+                                  'which does not fully conform to the FITS standard. '
+                                  'Setting default values now, set strict_fits=True '
+                                  'to error rather than warn on this problem, '
+                                  'rewrite this file with write_calfits to ensure '
+                                  'FITS compliance.'.format(file=filename))
+                    spw_array = np.array([0])
+                else:
+                    raise
             if not np.allclose(spw_array, self.spw_array):
                 raise ValueError('Spectral window values are different in TOTQLTY HDU than in primary HDU')
 

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -463,7 +463,7 @@ class CALFITS(UVCal):
                 raise ValueError('Jones values are different in FLAGS HDU than in primary HDU')
 
         # get total quality array if present
-        try:
+        if 'TOTQLTY' in hdunames:
             totqualhdu = F[hdunames['TOTQLTY']]
             self.total_quality_array = totqualhdu.data
 
@@ -498,7 +498,7 @@ class CALFITS(UVCal):
                                atol=self._jones_array.tols[0]):
                 raise ValueError('Jones values are different in TOTQLTY HDU than in primary HDU')
 
-        except KeyError:
+        else:
             self.total_quality_array = None
 
         if run_check:

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -473,6 +473,7 @@ class CALFITS(UVCal):
             totqualhdu = F[hdunames['TOTQLTY']]
             self.total_quality_array = totqualhdu.data
 
+            # add this for backwards compatibility when the spw CRVAL wasn't recorded
             try:
                 spw_array = uvutils.fits_gethduaxis(totqualhdu, 4, strict_fits=strict_fits)
             except(KeyError):

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -7,8 +7,6 @@ import utils as uvutils
 
 
 def _warn_oldcalfits(filename):
-    if filename is None:
-        filename = 'This file'
     warnings.warn('{file} appears to be an old calfits format '
                   'which does not fully conform to the FITS standard. '
                   'Setting default values now, set strict_fits=True '
@@ -114,7 +112,7 @@ class CALFITS(UVCal):
             prihdr['HASHCAL'] = self.git_hash_cal
 
         if self.cal_type == 'unknown':
-            raise ValueError("unknown calibration type. Do not know how to"
+            raise ValueError("unknown calibration type. Do not know how to "
                              "store parameters")
 
         if self.cal_type == 'gain':
@@ -400,7 +398,7 @@ class CALFITS(UVCal):
             except(KeyError):
                 if not strict_fits:
                     _warn_oldcalfits(filename)
-                    self.spw_array = np.array([0])
+                    self.spw_array = np.array([1])
                 else:
                     raise
 
@@ -431,7 +429,7 @@ class CALFITS(UVCal):
             except(KeyError):
                 if not strict_fits:
                     _warn_oldcalfits(filename)
-                    self.spw_array = np.array([0])
+                    self.spw_array = np.array([1])
                 else:
                     raise
 
@@ -446,7 +444,7 @@ class CALFITS(UVCal):
             except(KeyError):
                 if not strict_fits:
                     _warn_oldcalfits(filename)
-                    spw_array = np.array([0])
+                    spw_array = np.array([1])
                 else:
                     raise
             if not np.allclose(spw_array, self.spw_array):
@@ -475,7 +473,7 @@ class CALFITS(UVCal):
             except(KeyError):
                 if not strict_fits:
                     _warn_oldcalfits(filename)
-                    spw_array = np.array([0])
+                    spw_array = np.array([1])
                 else:
                     raise
             if not np.allclose(spw_array, self.spw_array):

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -49,6 +49,21 @@ def test_readwriteread_delays():
     del(uv_out)
 
 
+def test_errors():
+    """
+    Test for various errors.
+
+    """
+    uv_in = UVCal()
+    uv_out = UVCal()
+    testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
+    write_file = os.path.join(DATA_PATH, 'test/outtest_firstcal.fits')
+    uv_in.read_calfits(testfile)
+
+    uv_in.set_unknown_cal_type()
+    nt.assert_raises(ValueError, uv_in.write_calfits, write_file, clobber=True)
+
+
 def test_input_flag_array():
     """
     Test when data file has input flag array.

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -66,6 +66,58 @@ def test_errors():
     uv_in.set_unknown_cal_type()
     nt.assert_raises(ValueError, uv_in.write_calfits, write_file, run_check=False, clobber=True)
 
+    # change values for various axes in flag and total quality hdus to not match primary hdu
+    uv_in.read_calfits(testfile)
+
+    # Create filler jones info
+    uv_in.jones_array = np.array([-5, -6, -7, -8])
+    uv_in.Njones = 4
+    uv_in.flag_array = np.zeros(uv_in._flag_array.expected_shape(uv_in), dtype=bool)
+    uv_in.delay_array = np.ones(uv_in._delay_array.expected_shape(uv_in), dtype=np.float64)
+    uv_in.quality_array = np.zeros(uv_in._quality_array.expected_shape(uv_in))
+
+    # add total_quality_array so that can be tested as well
+    uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
+
+    header_vals_to_double = [{'flag': 'CDELT2'}, {'flag': 'CDELT3'},
+                             {'flag': 'CRVAL5'}, {'totqual': 'CDELT1'},
+                             {'totqual': 'CDELT2'}, {'totqual': 'CDELT3'},
+                             {'totqual': 'CRVAL4'}]
+    for i, hdr_dict in enumerate(header_vals_to_double):
+        uv_in.write_calfits(write_file, clobber=True)
+
+        unit = hdr_dict.keys()[0]
+        keyword = hdr_dict[unit]
+
+        F = fits.open(write_file)
+        data = F[0].data
+        primary_hdr = F[0].header
+        hdunames = uvutils.fits_indexhdus(F)
+        ant_hdu = F[hdunames['ANTENNAS']]
+        flag_hdu = F[hdunames['FLAGS']]
+        flag_hdr = flag_hdu.header
+        totqualhdu = F[hdunames['TOTQLTY']]
+        totqualhdr = totqualhdu.header
+
+        if unit == 'flag':
+            flag_hdr[keyword] *= 2
+        elif unit == 'totqual':
+            totqualhdr[keyword] *= 2
+
+        prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
+        hdulist = fits.HDUList([prihdu, ant_hdu])
+        flag_hdu = fits.ImageHDU(data=flag_hdu.data, header=flag_hdr)
+        hdulist.append(flag_hdu)
+        totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
+        hdulist.append(totqualhdu)
+
+        if float(astropy.__version__[0:3]) < 1.3:
+            hdulist.writeto(write_file, clobber=True)
+        else:
+            hdulist.writeto(write_file, overwrite=True)
+
+        nt.assert_raises(ValueError, uv_out.read_calfits, write_file, strict_fits=True)
+
 
 def test_read_oldcalfits():
     """
@@ -80,37 +132,46 @@ def test_read_oldcalfits():
 
     # add total_quality_array so that can be tested as well
     uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
-    uv_in.write_calfits(write_file, clobber=True)
 
     # now read in the file and remove various CRPIX and CRVAL keywords to
     # emulate old calfits files
-    F = fits.open(write_file)
-    data = F[0].data
-    primary_hdr = F[0].header
-    hdunames = uvutils.fits_indexhdus(F)
-    ant_hdu = F[hdunames['ANTENNAS']]
-    totqualhdu = F[hdunames['TOTQLTY']]
-    totqualhdr = totqualhdu.header
-
-    primary_hdr.pop('CRVAL5')
-    primary_hdr.pop('CRPIX4')
-    totqualhdr.pop('CRVAL4')
-
-    prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
-    hdulist = fits.HDUList([prihdu, ant_hdu])
-    totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
-    hdulist.append(totqualhdu)
-
-    if float(astropy.__version__[0:3]) < 1.3:
-        hdulist.writeto(write_file, clobber=True)
-    else:
-        hdulist.writeto(write_file, overwrite=True)
-
+    header_vals_to_remove = [{'primary': 'CRVAL5'}, {'primary': 'CRPIX4'},
+                             {'totqual': 'CRVAL4'}]
     messages = [write_file, 'This file', write_file]
     messages = [m + ' appears to be an old calfits format' for m in messages]
-    uvtest.checkWarnings(uv_out.read_calfits, [write_file], nwarnings=3,
-                         message=messages, category=[UserWarning] * 3)
-    nt.assert_equal(uv_in, uv_out)
+    for i, hdr_dict in enumerate(header_vals_to_remove):
+        uv_in.write_calfits(write_file, clobber=True)
+
+        unit = hdr_dict.keys()[0]
+        keyword = hdr_dict[unit]
+
+        F = fits.open(write_file)
+        data = F[0].data
+        primary_hdr = F[0].header
+        hdunames = uvutils.fits_indexhdus(F)
+        ant_hdu = F[hdunames['ANTENNAS']]
+        totqualhdu = F[hdunames['TOTQLTY']]
+        totqualhdr = totqualhdu.header
+
+        if unit == 'primary':
+            primary_hdr.pop(keyword)
+        elif unit == 'totqual':
+            totqualhdr.pop(keyword)
+
+        prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
+        hdulist = fits.HDUList([prihdu, ant_hdu])
+        totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
+        hdulist.append(totqualhdu)
+
+        if float(astropy.__version__[0:3]) < 1.3:
+            hdulist.writeto(write_file, clobber=True)
+        else:
+            hdulist.writeto(write_file, overwrite=True)
+
+        uvtest.checkWarnings(uv_out.read_calfits, [write_file], nwarnings=1,
+                             message=messages[i], category=[UserWarning])
+        nt.assert_equal(uv_in, uv_out)
+        nt.assert_raises(KeyError, uv_out.read_calfits, write_file, strict_fits=True)
 
     # now with delay type files
     uv_in = UVCal()
@@ -121,43 +182,52 @@ def test_read_oldcalfits():
 
     # add total_quality_array so that can be tested as well
     uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
-    uv_in.write_calfits(write_file, clobber=True)
 
     # now read in the file and remove various CRPIX and CRVAL keywords to
     # emulate old calfits files
-    F = fits.open(write_file)
-    data = F[0].data
-    primary_hdr = F[0].header
-    hdunames = uvutils.fits_indexhdus(F)
-    ant_hdu = F[hdunames['ANTENNAS']]
-    flag_hdu = F[hdunames['FLAGS']]
-    flag_hdr = flag_hdu.header
-    totqualhdu = F[hdunames['TOTQLTY']]
-    totqualhdr = totqualhdu.header
-
-    primary_hdr.pop('CRVAL4')
-    flag_hdr.pop('CRVAL5')
-    flag_hdr.pop('CRPIX4')
-    totqualhdr.pop('CRVAL4')
-
-    prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
-    hdulist = fits.HDUList([prihdu, ant_hdu])
-    flag_hdu = fits.ImageHDU(data=flag_hdu.data, header=flag_hdr)
-    hdulist.append(flag_hdu)
-    totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
-    hdulist.append(totqualhdu)
-
-    if float(astropy.__version__[0:3]) < 1.3:
-        hdulist.writeto(write_file, clobber=True)
-    else:
-        hdulist.writeto(write_file, overwrite=True)
-
-    messages = [write_file, 'This file', write_file, write_file]
+    header_vals_to_remove = [{'primary': 'CRVAL4'}, {'flag': 'CRVAL5'},
+                             {'flag': 'CRPIX4'}, {'totqual': 'CRVAL4'}]
+    messages = [write_file, 'This file', 'This file', write_file]
     messages = [m + ' appears to be an old calfits format' for m in messages]
-    print(messages)
-    uvtest.checkWarnings(uv_out.read_calfits, [write_file], nwarnings=4,
-                         message=messages, category=[UserWarning] * 4)
-    nt.assert_equal(uv_in, uv_out)
+    for i, hdr_dict in enumerate(header_vals_to_remove):
+        uv_in.write_calfits(write_file, clobber=True)
+
+        unit = hdr_dict.keys()[0]
+        keyword = hdr_dict[unit]
+
+        F = fits.open(write_file)
+        data = F[0].data
+        primary_hdr = F[0].header
+        hdunames = uvutils.fits_indexhdus(F)
+        ant_hdu = F[hdunames['ANTENNAS']]
+        flag_hdu = F[hdunames['FLAGS']]
+        flag_hdr = flag_hdu.header
+        totqualhdu = F[hdunames['TOTQLTY']]
+        totqualhdr = totqualhdu.header
+
+        if unit == 'primary':
+            primary_hdr.pop(keyword)
+        elif unit == 'flag':
+            flag_hdr.pop(keyword)
+        elif unit == 'totqual':
+            totqualhdr.pop(keyword)
+
+        prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
+        hdulist = fits.HDUList([prihdu, ant_hdu])
+        flag_hdu = fits.ImageHDU(data=flag_hdu.data, header=flag_hdr)
+        hdulist.append(flag_hdu)
+        totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
+        hdulist.append(totqualhdu)
+
+        if float(astropy.__version__[0:3]) < 1.3:
+            hdulist.writeto(write_file, clobber=True)
+        else:
+            hdulist.writeto(write_file, overwrite=True)
+
+        uvtest.checkWarnings(uv_out.read_calfits, [write_file], nwarnings=1,
+                             message=messages[i], category=[UserWarning])
+        nt.assert_equal(uv_in, uv_out)
+        nt.assert_raises(KeyError, uv_out.read_calfits, write_file, strict_fits=True)
 
 
 def test_input_flag_array():

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -1,9 +1,12 @@
 """Tests for calfits object"""
 import nose.tools as nt
 import os
+import astropy
+from astropy.io import fits
 from pyuvdata.uvcal import UVCal
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
+import pyuvdata.utils as uvutils
 import numpy as np
 
 
@@ -61,7 +64,100 @@ def test_errors():
     uv_in.read_calfits(testfile)
 
     uv_in.set_unknown_cal_type()
-    nt.assert_raises(ValueError, uv_in.write_calfits, write_file, clobber=True)
+    nt.assert_raises(ValueError, uv_in.write_calfits, write_file, run_check=False, clobber=True)
+
+
+def test_read_oldcalfits():
+    """
+    Test for proper behavior with old calfits files.
+    """
+    # start with gain type files
+    uv_in = UVCal()
+    uv_out = UVCal()
+    testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.fitsA')
+    write_file = os.path.join(DATA_PATH, 'test/outtest_omnical.fits')
+    uv_in.read_calfits(testfile)
+
+    # add total_quality_array so that can be tested as well
+    uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
+    uv_in.write_calfits(write_file, clobber=True)
+
+    # now read in the file and remove various CRPIX and CRVAL keywords to
+    # emulate old calfits files
+    F = fits.open(write_file)
+    data = F[0].data
+    primary_hdr = F[0].header
+    hdunames = uvutils.fits_indexhdus(F)
+    ant_hdu = F[hdunames['ANTENNAS']]
+    totqualhdu = F[hdunames['TOTQLTY']]
+    totqualhdr = totqualhdu.header
+
+    primary_hdr.pop('CRVAL5')
+    primary_hdr.pop('CRPIX4')
+    totqualhdr.pop('CRVAL4')
+
+    prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
+    hdulist = fits.HDUList([prihdu, ant_hdu])
+    totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
+    hdulist.append(totqualhdu)
+
+    if float(astropy.__version__[0:3]) < 1.3:
+        hdulist.writeto(write_file, clobber=True)
+    else:
+        hdulist.writeto(write_file, overwrite=True)
+
+    messages = [write_file, 'This file', write_file]
+    messages = [m + ' appears to be an old calfits format' for m in messages]
+    uvtest.checkWarnings(uv_out.read_calfits, [write_file], nwarnings=3,
+                         message=messages, category=[UserWarning] * 3)
+    nt.assert_equal(uv_in, uv_out)
+
+    # now with delay type files
+    uv_in = UVCal()
+    uv_out = UVCal()
+    testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
+    write_file = os.path.join(DATA_PATH, 'test/outtest_firstcal.fits')
+    uv_in.read_calfits(testfile)
+
+    # add total_quality_array so that can be tested as well
+    uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
+    uv_in.write_calfits(write_file, clobber=True)
+
+    # now read in the file and remove various CRPIX and CRVAL keywords to
+    # emulate old calfits files
+    F = fits.open(write_file)
+    data = F[0].data
+    primary_hdr = F[0].header
+    hdunames = uvutils.fits_indexhdus(F)
+    ant_hdu = F[hdunames['ANTENNAS']]
+    flag_hdu = F[hdunames['FLAGS']]
+    flag_hdr = flag_hdu.header
+    totqualhdu = F[hdunames['TOTQLTY']]
+    totqualhdr = totqualhdu.header
+
+    primary_hdr.pop('CRVAL4')
+    flag_hdr.pop('CRVAL5')
+    flag_hdr.pop('CRPIX4')
+    totqualhdr.pop('CRVAL4')
+
+    prihdu = fits.PrimaryHDU(data=data, header=primary_hdr)
+    hdulist = fits.HDUList([prihdu, ant_hdu])
+    flag_hdu = fits.ImageHDU(data=flag_hdu.data, header=flag_hdr)
+    hdulist.append(flag_hdu)
+    totqualhdu = fits.ImageHDU(data=totqualhdu.data, header=totqualhdr)
+    hdulist.append(totqualhdu)
+
+    if float(astropy.__version__[0:3]) < 1.3:
+        hdulist.writeto(write_file, clobber=True)
+    else:
+        hdulist.writeto(write_file, overwrite=True)
+
+    messages = [write_file, 'This file', write_file, write_file]
+    messages = [m + ' appears to be an old calfits format' for m in messages]
+    print(messages)
+    uvtest.checkWarnings(uv_out.read_calfits, [write_file], nwarnings=4,
+                         message=messages, category=[UserWarning] * 4)
+    nt.assert_equal(uv_in, uv_out)
 
 
 def test_input_flag_array():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -220,7 +220,7 @@ def get_iterable(x):
         return (x,)
 
 
-def fits_gethduaxis(HDU, axis):
+def fits_gethduaxis(HDU, axis, strict_fits=True):
     """
     Helper function for making axis arrays for fits files.
 
@@ -236,10 +236,20 @@ def fits_gethduaxis(HDU, axis):
     N = HDU.header['NAXIS' + ax]
     X0 = HDU.header['CRVAL' + ax]
     dX = HDU.header['CDELT' + ax]
+    # add this for calfits backwards compatibility when the CRPIX values were often assumed to be 0
     try:
         Xi0 = HDU.header['CRPIX' + ax] - 1
     except(KeyError):
-        Xi0 = 0
+        if not strict_fits:
+            warnings.warn('This file appears to be an old calfits format '
+                          'which does not fully conform to the FITS standard. '
+                          'Setting default values now, set strict_fits=True '
+                          'to error rather than warn on this problem, '
+                          'rewrite this file with write_calfits to ensure '
+                          'FITS compliance.'.format(file=filename))
+            Xi0 = 0
+        else:
+            raise
     return dX * (np.arange(N) - Xi0) + X0
 
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -247,7 +247,7 @@ def fits_gethduaxis(HDU, axis, strict_fits=True):
                           'Setting default values now, set strict_fits=True '
                           'to error rather than warn on this problem, '
                           'rewrite this file with write_calfits to ensure '
-                          'FITS compliance.'.format(file=filename))
+                          'FITS compliance.')
             Xi0 = 0
         else:
             raise

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -228,7 +228,11 @@ def fits_gethduaxis(HDU, axis, strict_fits=True):
     Args:
         HDU: a fits HDU
         axis: the axis number of interest
-
+        strict_fits: boolean
+            If True, require that the axis has cooresponding NAXIS, CRVAL,
+            CDELT and CRPIX keywords. If False, allow CRPIX to be missing and
+            set it equal to zero (as a way of supporting old calfits files).
+            Default is False.
     Returns:
         numpy array of values for that axis
     """
@@ -242,12 +246,8 @@ def fits_gethduaxis(HDU, axis, strict_fits=True):
         Xi0 = HDU.header['CRPIX' + ax] - 1
     except(KeyError):
         if not strict_fits:
-            warnings.warn('This file appears to be an old calfits format '
-                          'which does not fully conform to the FITS standard. '
-                          'Setting default values now, set strict_fits=True '
-                          'to error rather than warn on this problem, '
-                          'rewrite this file with write_calfits to ensure '
-                          'FITS compliance.')
+            import calfits
+            calfits._warn_oldcalfits()
             Xi0 = 0
         else:
             raise

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -247,7 +247,7 @@ def fits_gethduaxis(HDU, axis, strict_fits=True):
     except(KeyError):
         if not strict_fits:
             import calfits
-            calfits._warn_oldcalfits()
+            calfits._warn_oldcalfits('This file')
             Xi0 = 0
         else:
             raise

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -211,6 +211,7 @@ def top2eq_m(ha, dec):
         mat = mat.transpose([2, 0, 1])
     return mat
 
+
 def get_iterable(x):
     """Helper function to ensure iterability."""
     if isinstance(x, collections.Iterable):
@@ -235,7 +236,10 @@ def fits_gethduaxis(HDU, axis):
     N = HDU.header['NAXIS' + ax]
     X0 = HDU.header['CRVAL' + ax]
     dX = HDU.header['CDELT' + ax]
-    Xi0 = HDU.header['CRPIX' + ax] - 1
+    try:
+        Xi0 = HDU.header['CRPIX' + ax] - 1
+    except(KeyError):
+        Xi0 = 0
     return dX * (np.arange(N) - Xi0) + X0
 
 

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -1,6 +1,7 @@
 """Commonly used utility functions."""
 import numpy as np
 import collections
+import warnings
 
 # parameters for transforming between xyz & lat/lon/alt
 gps_b = 6356752.31424518

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -511,7 +511,8 @@ class UVCal(UVBase):
             setattr(other_obj, p, param)
         return other_obj
 
-    def read_calfits(self, filename, run_check=True, run_check_acceptability=True):
+    def read_calfits(self, filename, run_check=True, run_check_acceptability=True,
+                     strict_fits=False):
         """
         Read in data from a calfits file.
 
@@ -521,7 +522,8 @@ class UVCal(UVBase):
         import calfits
         uvfits_obj = calfits.CALFITS()
         uvfits_obj.read_calfits(filename, run_check=run_check,
-                                run_check_acceptability=run_check_acceptability)
+                                run_check_acceptability=run_check_acceptability,
+                                strict_fits=strict_fits)
         self._convert_from_filetype(uvfits_obj)
         del(uvfits_obj)
 

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -517,7 +517,18 @@ class UVCal(UVBase):
         Read in data from a calfits file.
 
         Args:
-            filename: The uvfits file to read from.
+            filename: The calfits file to read to.
+            run_check: Option to check for the existence and proper shapes of
+                required parameters after reading the file. Default is True.
+            run_check_acceptability: Option to check acceptability of the values of
+                required parameters after reading the file. Default is True.
+            strict_fits: boolean
+                If True, require that the data axes have cooresponding NAXIS, CRVAL,
+                CDELT and CRPIX keywords. If False, allow CRPIX to be missing and
+                set it equal to zero and allow the CRVAL for the spw directions to
+                be missing and set it to zero. This keyword exists to support old
+                calfits files that were missing many CRPIX and CRVAL keywords.
+                Default is False.
         """
         import calfits
         uvfits_obj = calfits.CALFITS()
@@ -527,7 +538,7 @@ class UVCal(UVBase):
         self._convert_from_filetype(uvfits_obj)
         del(uvfits_obj)
 
-    def write_calfits(self, filename,  run_check=True, run_check_acceptability=True,
+    def write_calfits(self, filename, run_check=True, run_check_acceptability=True,
                       clobber=False):
         """Write data to a calfits file.
 


### PR DESCRIPTION
This PR adds backwards compatibility for old calfits files, with warnings issued when problems are discovered and with a keyword option (strict_fits) on read_calfits to allow for overriding the compatibility code.