### PR TITLE
Update calfits object and tests so delay-type fits have same rank as …

### DIFF
--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -183,7 +183,6 @@ class CALFITS(UVCal):
                                          axis=-1)
 
         elif self.cal_type == 'delay':
-            # we add an extra axis in the middle for frequencies
             pridata = np.concatenate([self.delay_array[:, :, :, :, :, np.newaxis],
                                       self.quality_array[:, :, :, :, :, np.newaxis]],
                                      axis=-1)

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -232,7 +232,7 @@ def test_read_oldcalfits():
 
     # now read in the file and remove various CRPIX and CRVAL keywords to
     # emulate old calfits files
-    header_vals_to_remove = [{'primary': 'CRVAL4'}, {'flag': 'CRVAL5'},
+    header_vals_to_remove = [{'primary': 'CRVAL5'}, {'flag': 'CRVAL5'},
                              {'flag': 'CRPIX4'}, {'totqual': 'CRVAL4'}]
     messages = [write_file, 'This file', 'This file', write_file]
     messages = [m + ' appears to be an old calfits format' for m in messages]

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -177,7 +177,7 @@ class TestUVCalBasicMethods(object):
             else:
                 conv = 1
             nt.assert_true(np.allclose(np.angle(self.new_object.gain_array[:, :, 10, :, :]) % (2 * np.pi),
-                                       (conv * 2 * np.pi * self.delay_object.delay_array *
+                                       (conv * 2 * np.pi * self.delay_object.delay_array[:, :, 0, :, :] *
                                        self.delay_object.freq_array[0, 10]) % (2 * np.pi),
                                        rtol=self.new_object._gain_array.tols[0],
                                        atol=self.new_object._gain_array.tols[1]))
@@ -495,11 +495,11 @@ class TestUVCalSelectDelay(object):
                                                        self.delay_object.flag_array[:, :, :, [-1], :]),
                                                       axis=3)
         self.delay_object.delay_array = np.concatenate((self.delay_object.delay_array,
-                                                        self.delay_object.delay_array[:, :, [-1], :]),
-                                                       axis=2)
+                                                        self.delay_object.delay_array[:, :, :, [-1], :]),
+                                                       axis=3)
         self.delay_object.quality_array = np.concatenate((self.delay_object.quality_array,
-                                                          self.delay_object.quality_array[:, :, [-1], :]),
-                                                         axis=2)
+                                                          self.delay_object.quality_array[:, :, :, [-1], :]),
+                                                         axis=3)
         nt.assert_true(self.delay_object.check())
         self.delay_object2 = copy.deepcopy(self.delay_object)
 
@@ -594,11 +594,11 @@ class TestUVCalSelectDelay(object):
                                                                  self.delay_object.input_flag_array[:, :, :, :, [-1]]),
                                                                 axis=4)
             self.delay_object.delay_array = np.concatenate((self.delay_object.delay_array,
-                                                            self.delay_object.delay_array[:, :, :, [-1]]),
-                                                           axis=3)
+                                                            self.delay_object.delay_array[:, :, :, :, [-1]]),
+                                                           axis=4)
             self.delay_object.quality_array = np.concatenate((self.delay_object.quality_array,
-                                                              self.delay_object.quality_array[:, :, :, [-1]]),
-                                                             axis=3)
+                                                              self.delay_object.quality_array[:, :, :, :, [-1]]),
+                                                             axis=4)
         nt.assert_true(self.delay_object.check())
         self.delay_object2 = copy.deepcopy(self.delay_object)
 


### PR DESCRIPTION
…gain-type. Previously, gain-type and delay-type objects had a different rank for the solutions, as well as quality objects. Tests and parameter definitions have been changed to make them equal rank, and a warning is raised when reading an "old" delay file.