### PR TITLE
Catch warnings when reading old data formats during tests

### DIFF
--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -44,7 +44,9 @@ def test_readwriteread_delays():
     uv_out = UVCal()
     testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_firstcal.fits')
-    uv_in.read_calfits(testfile)
+    message = testfile + ' appears to be an old calfits format'
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
     uv_in.write_calfits(write_file, clobber=True)
     uv_out.read_calfits(write_file)
     nt.assert_equal(uv_in, uv_out)
@@ -61,13 +63,16 @@ def test_errors():
     uv_out = UVCal()
     testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_firstcal.fits')
-    uv_in.read_calfits(testfile)
+    message = testfile + ' appears to be an old calfits format'
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
 
     uv_in.set_unknown_cal_type()
     nt.assert_raises(ValueError, uv_in.write_calfits, write_file, run_check=False, clobber=True)
 
     # change values for various axes in flag and total quality hdus to not match primary hdu
-    uv_in.read_calfits(testfile)
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
 
     # Create filler jones info
     uv_in.jones_array = np.array([-5, -6, -7, -8])
@@ -225,7 +230,9 @@ def test_read_oldcalfits():
     uv_out = UVCal()
     testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_firstcal.fits')
-    uv_in.read_calfits(testfile)
+    message = testfile + ' appears to be an old calfits format'
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
 
     # add total_quality_array so that can be tested as well
     uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
@@ -296,7 +303,9 @@ def test_input_flag_array():
 
     # Repeat for delay version
     testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
-    uv_in.read_calfits(testfile)
+    message = testfile + ' appears to be an old calfits format'
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
     uv_in.input_flag_array = np.zeros(uv_in._input_flag_array.expected_shape(uv_in), dtype=bool)
     uv_in.write_calfits(write_file, clobber=True)
     uv_out.read_calfits(write_file)
@@ -331,7 +340,9 @@ def test_jones():
 
     # Repeat for delay version
     testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
-    uv_in.read_calfits(testfile)
+    message = testfile + ' appears to be an old calfits format'
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
 
     # Create filler jones info
     uv_in.jones_array = np.array([-5, -6, -7, -8])
@@ -374,7 +385,9 @@ def test_readwriteread_total_quality_array():
     uv_out = UVCal()
     testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
     write_file = os.path.join(DATA_PATH, 'test/outtest_total_quality_array_delays.fits')
-    uv_in.read_calfits(testfile)
+    message = testfile + ' appears to be an old calfits format'
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
 
     uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
 

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -113,7 +113,9 @@ class TestUVCalBasicMethods(object):
         self.gain_object2 = copy.deepcopy(self.gain_object)
         self.delay_object = UVCal()
         delayfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
-        self.delay_object.read_calfits(delayfile)
+        message = delayfile + ' appears to be an old calfits format'
+        uvtest.checkWarnings(self.delay_object.read_calfits, [delayfile], nwarnings=1,
+                             message=message, category=[UserWarning])
 
     def teardown(self):
         """Tear down test"""
@@ -441,7 +443,9 @@ class TestUVCalSelectDelay(object):
         # add an input flag array to the file to test for that.
         write_file = os.path.join(DATA_PATH, 'test/outtest_input_flags.fits')
         uv_in = UVCal()
-        uv_in.read_calfits(delayfile)
+        message = delayfile + ' appears to be an old calfits format'
+        uvtest.checkWarnings(uv_in.read_calfits, [delayfile], nwarnings=1,
+                             message=message, category=[UserWarning])
         uv_in.input_flag_array = np.zeros(uv_in._input_flag_array.expected_shape(uv_in), dtype=bool)
         uv_in.write_calfits(write_file, clobber=True)
 


### PR DESCRIPTION
This change wraps the reading of old calfits files with a way to properly catch and check the warnings during testing. These warning messages are no longer displayed when tests are run.