### PR TITLE
Fix form selection of total_quality_array

### DIFF
--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -396,3 +396,34 @@ def test_readwriteread_total_quality_array():
     nt.assert_equal(uv_in, uv_out)
     del(uv_in)
     del(uv_out)
+
+
+def test_total_quality_array_size():
+    """
+    Test that total quality array defaults to the proper size
+    """
+
+    uv_in = UVCal()
+    uv_out = UVCal()
+    testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.fitsA')
+    uv_in.read_calfits(testfile)
+
+    # Create filler total quality array
+    uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
+
+    proper_shape = (uv_in.Nspws, uv_in.Nfreqs, uv_in.Ntimes, uv_in.Njones)
+    nt.assert_equal(uv_in.total_quality_array.shape, proper_shape)
+    del(uv_in)
+
+    # also test delay-type calibrations
+    uv_in = UVCal()
+    testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvc.fits')
+    message = testfile + ' appears to be an old calfits format'
+    uvtest.checkWarnings(uv_in.read_calfits, [testfile], nwarnings=1,
+                         message=message, category=[UserWarning])
+
+    uv_in.total_quality_array = np.zeros(uv_in._total_quality_array.expected_shape(uv_in))
+
+    proper_shape = (uv_in.Nspws, 1, uv_in.Ntimes, uv_in.Njones)
+    nt.assert_equal(uv_in.total_quality_array.shape, proper_shape)
+    del(uv_in)

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -221,8 +221,6 @@ class UVCal(UVBase):
                 'if cal_type is delay, shape is (Nspws, 1, Ntimes, Njones), '
                 'type = float.')
         self._total_quality_array = uvp.UVParameter('total_quality_array', description=desc,
-                                                    form=('Nspws', 'Nfreqs',
-                                                          'Ntimes', 'Njones'),
                                                     expected_type=np.float,
                                                     required=False)
 
@@ -244,6 +242,7 @@ class UVCal(UVBase):
         self._delay_array.required = False
         self._freq_range.required = False
         self._quality_array.form = self._gain_array.form
+        self._total_quality_array.form = self._gain_array.form[1:]
 
     def set_delay(self):
         """Set cal_type to 'delay' and adjust required parameters."""
@@ -252,6 +251,7 @@ class UVCal(UVBase):
         self._delay_array.required = True
         self._freq_range.required = True
         self._quality_array.form = self._delay_array.form
+        self._total_quality_array.form = self._delay_array.form[1:]
 
     def set_unknown_cal_type(self):
         """Set cal_type to 'unknown' and adjust required parameters."""
@@ -260,6 +260,7 @@ class UVCal(UVBase):
         self._delay_array.required = False
         self._freq_range.required = False
         self._quality_array.form = self._gain_array.form
+        self._total_quality_array.form = self._gain_array.form[1:]
 
     def select(self, antenna_nums=None, antenna_names=None,
                frequencies=None, freq_chans=None,

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -221,6 +221,8 @@ class UVCal(UVBase):
                 'if cal_type is delay, shape is (Nspws, 1, Ntimes, Njones), '
                 'type = float.')
         self._total_quality_array = uvp.UVParameter('total_quality_array', description=desc,
+                                                    form=('Nspws', 'Nfreqs',
+                                                          'Ntimes', 'Njones'),
                                                     expected_type=np.float,
                                                     required=False)
 


### PR DESCRIPTION
The form of total_quality_array was not being set for different delay types. This change fixes that bug. The intrinsic shape of the total_quality_array has been removed as well, since its shape depends only on `_gain_array.form` or `_delay_array.form` and drops the `Nants_data` dimension.