### PR TITLE
Add __add__ method for UVCal

### DIFF
--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -991,6 +991,21 @@ class TestUVCalAddGain(object):
                                     rtol=self.gain_object._freq_array.tols[0],
                                     atol=self.gain_object._freq_array.tols[1]))
 
+    def test_parameter_warnings(self):
+        """Test changing a parameter that will raise a warning"""
+        # change observer and select frequencies
+        self.gain_object2.observer = 'mystery_person'
+        freqs1 = self.gain_object.freq_array[0, np.arange(0, 512)]
+        freqs2 = self.gain_object2.freq_array[0, np.arange(512, 1024)]
+        self.gain_object.select(frequencies=freqs1)
+        self.gain_object2.select(frequencies=freqs2)
+        uvtest.checkWarnings(self.gain_object.__iadd__, [self.gain_object2],
+                             message='UVParameter observer does not match')
+        freqs = np.concatenate([freqs1, freqs2])
+        nt.assert_true(np.allclose(self.gain_object.freq_array, freqs,
+                                   rtol=self.gain_object._freq_array.tols[0],
+                                   atol=self.gain_object._freq_array.tols[1]))
+
 class TestUVCalAddDelay(object):
     def setUp(self):
         """Set up test"""
@@ -1226,3 +1241,8 @@ class TestUVCalAddDelay(object):
         self.delay_object2.input_flag_array = ifa2
         self.delay_object += self.delay_object2
         nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
+
+    def test_add_errors(self):
+        """Test behavior that will raise errors"""
+        # test addition of two identical objects
+        nt.assert_raises(ValueError, self.delay_object.__add__, self.delay_object2)

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -884,30 +884,40 @@ class TestUVCalAddGain(object):
 
     def test_add(self):
         """Test miscellaneous aspects of add method"""
-        # test addition of two identical objects
-        nt.assert_raises(ValueError, self.gain_object.__add__, [self.gain_object2])
-
         # test not-in-place addition
-        gain_object_full = copy.deepcopy(self.gain_object)
+        gain_object = copy.deepcopy(self.gain_object)
         ants1 = np.array([9, 10, 20, 22, 31, 43, 53, 64, 65, 72])
         ants2 = np.array([80, 81, 88, 89, 96, 97, 104, 105, 112])
         self.gain_object.select(antenna_nums=ants1)
         self.gain_object2.select(antenna_nums=ants2)
         gain_object_add = self.gain_object + self.gain_object2
         # Check history is correct, before replacing and doing a full object check
-        nt.assert_equal(gain_object_full.history + '  Downselected to specific '
+        nt.assert_equal(gain_object.history + '  Downselected to specific '
                         'antennas using pyuvdata. Combined data along antenna '
                         'axis using pyuvdata.', gain_object_add.history)
-        gain_object_add.history = gain_object_full.history
-        nt.assert_equal(gain_object_add, gain_object_full)
+        gain_object_add.history = gain_object.history
+        nt.assert_equal(gain_object_add, gain_object)
 
         # test history concatenation
-        self.gain_object.history = gain_object_full.history
+        self.gain_object.history = gain_object.history
         self.gain_object2.history = 'Some random history string'
         self.gain_object += self.gain_object2
-        nt.assert_equal(gain_object_full.history + ' Combined data along '
+        nt.assert_equal(gain_object.history + ' Combined data along '
                         'antenna axis using pyuvdata. Some random history string',
                         self.gain_object.history)
+
+    def test_add_errors(self):
+        """Test behavior that will raise errors"""
+        # test addition of two identical objects
+        nt.assert_raises(ValueError, self.gain_object.__add__, self.gain_object2)
+
+        # test addition of UVCal and non-UVCal object (empty list)
+        nt.assert_raises(ValueError, self.gain_object.__add__, [])
+
+        # test compatibility param mismatch
+        telescope_name = self.gain_object2.telescope_name
+        self.gain_object2.telescope_name = "PAPER"
+        nt.assert_raises(ValueError, self.gain_object.__add__, self.gain_object2)
 
 class TestUVCalAddDelay(object):
     def setUp(self):

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -882,6 +882,33 @@ class TestUVCalAddGain(object):
                                    rtol=self.gain_object._total_quality_array.tols[0],
                                    atol=self.gain_object._total_quality_array.tols[1]))
 
+    def test_add(self):
+        """Test miscellaneous aspects of add method"""
+        # test addition of two identical objects
+        nt.assert_raises(ValueError, self.gain_object.__add__, [self.gain_object2])
+
+        # test not-in-place addition
+        gain_object_full = copy.deepcopy(self.gain_object)
+        ants1 = np.array([9, 10, 20, 22, 31, 43, 53, 64, 65, 72])
+        ants2 = np.array([80, 81, 88, 89, 96, 97, 104, 105, 112])
+        self.gain_object.select(antenna_nums=ants1)
+        self.gain_object2.select(antenna_nums=ants2)
+        gain_object_add = self.gain_object + self.gain_object2
+        # Check history is correct, before replacing and doing a full object check
+        nt.assert_equal(gain_object_full.history + '  Downselected to specific '
+                        'antennas using pyuvdata. Combined data along antenna '
+                        'axis using pyuvdata.', gain_object_add.history)
+        gain_object_add.history = gain_object_full.history
+        nt.assert_equal(gain_object_add, gain_object_full)
+
+        # test history concatenation
+        self.gain_object.history = gain_object_full.history
+        self.gain_object2.history = 'Some random history string'
+        self.gain_object += self.gain_object2
+        nt.assert_equal(gain_object_full.history + ' Combined data along '
+                        'antenna axis using pyuvdata. Some random history string',
+                        self.gain_object.history)
+
 class TestUVCalAddDelay(object):
     def setUp(self):
         """Set up test"""

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -928,6 +928,30 @@ class TestUVCalAddDelay(object):
                              message='Total quality array detected')
         nt.assert_equal(self.delay_object.total_quality_array, None)
 
+        # test for when input_flag_array is present in first file but not second
+        self.delay_object.select(antenna_nums=ants1)
+        ifa = np.zeros(
+            self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)
+        ifa2 = np.ones(
+            self.delay_object2._input_flag_array.expected_shape(self.delay_object2)).astype(np.bool)
+        tot_ifa = np.concatenate([ifa, ifa2], axis=0)
+        self.delay_object.input_flag_array = ifa
+        self.delay_object2.input_flag_array = None
+        self.delay_object += self.delay_object2
+        nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
+
+        # test for when input_flag_array is present in second file but not first
+        self.delay_object.select(antenna_nums=ants1)
+        ifa = np.ones(
+            self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)
+        ifa2 = np.zeros(
+            self.delay_object2._input_flag_array.expected_shape(self.delay_object2)).astype(np.bool)
+        tot_ifa = np.concatenate([ifa, ifa2], axis=0)
+        self.delay_object.input_flag_array = None
+        self.delay_object2.input_flag_array = ifa2
+        self.delay_object += self.delay_object2
+        nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
+
     def test_add_times(self):
         """Test adding times between two UVCal objects"""
         delay_object_full = copy.deepcopy(self.delay_object)
@@ -990,6 +1014,34 @@ class TestUVCalAddDelay(object):
                                    rtol=self.delay_object._total_quality_array.tols[0],
                                    atol=self.delay_object._total_quality_array.tols[1]))
 
+        # test for when input_flag_array is present in first file but not second
+        ### XXX: See above
+        self.delay_object.total_quality_array = None
+        self.delay_object.select(times=times1)
+        ifa = np.zeros(
+            self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)
+        ifa2 = np.ones(
+            self.delay_object2._input_flag_array.expected_shape(self.delay_object2)).astype(np.bool)
+        tot_ifa = np.concatenate([ifa, ifa2], axis=3)
+        self.delay_object.input_flag_array = ifa
+        self.delay_object2.input_flag_array = None
+        self.delay_object += self.delay_object2
+        nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
+
+        # test for when input_flag_array is present in second file but not first
+        ### XXX: See above
+        self.delay_object.total_quality_array = None
+        self.delay_object.select(times=times1)
+        ifa = np.ones(
+            self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)
+        ifa2 = np.zeros(
+            self.delay_object2._input_flag_array.expected_shape(self.delay_object2)).astype(np.bool)
+        tot_ifa = np.concatenate([ifa, ifa2], axis=3)
+        self.delay_object.input_flag_array = None
+        self.delay_object2.input_flag_array = ifa2
+        self.delay_object += self.delay_object2
+        nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
+
     def test_add_jones(self):
         """Test adding Jones axes between two UVCal objects"""
         delay_object_original = copy.deepcopy(self.delay_object)
@@ -1041,3 +1093,27 @@ class TestUVCalAddDelay(object):
         nt.assert_true(np.allclose(self.delay_object.total_quality_array, tot_tqa,
                                    rtol=self.delay_object._total_quality_array.tols[0],
                                    atol=self.delay_object._total_quality_array.tols[1]))
+
+        # test for when input_flag_array is present in first file but not second
+        self.delay_object = copy.deepcopy(delay_object_original)
+        ifa = np.zeros(
+            self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)
+        ifa2 = np.ones(
+            self.delay_object2._input_flag_array.expected_shape(self.delay_object2)).astype(np.bool)
+        tot_ifa = np.concatenate([ifa, ifa2], axis=4)
+        self.delay_object.input_flag_array = ifa
+        self.delay_object2.input_flag_array = None
+        self.delay_object += self.delay_object2
+        nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
+
+        # test for when input_flag_array is present in second file but not first
+        self.delay_object = copy.deepcopy(delay_object_original)
+        ifa = np.ones(
+            self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)
+        ifa2 = np.zeros(
+            self.delay_object2._input_flag_array.expected_shape(self.delay_object2)).astype(np.bool)
+        tot_ifa = np.concatenate([ifa, ifa2], axis=4)
+        self.delay_object.input_flag_array = None
+        self.delay_object2.input_flag_array = ifa2
+        self.delay_object += self.delay_object2
+        nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -670,3 +670,31 @@ class TestUVCalSelectDelay(object):
         nt.assert_equal(old_history + '  Downselected to specific antennas, '
                         'times, frequencies, jones polarization terms using pyuvdata.',
                         self.delay_object2.history)
+
+class TestUVCalAddGain(object):
+    def setUp(self):
+        """Set up test"""
+        self.gain_object = UVCal()
+        gainfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.fitsA')
+        self.gain_object.read_calfits(gainfile)
+        self.gain_object2 = copy.deepcopy(self.gain_object)
+
+    def teardown(self):
+        """Tear down test"""
+        del(self.gain_object)
+        del(self.gain_object2)
+
+    def test_add_antennas(self):
+        """Test adding antennas between two UVCal objects"""
+        gain_object_full = copy.deepcopy(self.gain_object)
+        ants1 = np.array([9, 10, 20, 22, 31, 43, 53, 64, 65, 72])
+        ants2 = np.array([80, 81, 88, 89, 96, 97, 104, 105, 112])
+        self.gain_object.select(antenna_nums=ants1)
+        self.gain_object2.select(antenna_nums=ants2)
+        self.gain_object += self.gain_object2
+        # Check history is correct, before replacing and doing a full object check
+        nt.assert_equal(gain_object_full.history + '  Downselected to specific '
+                        'antennas using pyuvdata. Combined data along antenna '
+                        'axis using pyuvdata.', self.gain_object.history)
+        self.gain_object.history = gain_object_full.history
+        nt.assert_equal(self.gain_object, gain_object_full)

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -971,15 +971,21 @@ class TestUVCalAddGain(object):
                              message='Combined frequencies are not evenly spaced')
         nt.assert_equal(len(self.gain_object.freq_array[0,:]), self.gain_object.Nfreqs)
 
-        # now check having non-contiguous frequencies
+        # now check having "non-contiguous" frequencies
         self.gain_object = copy.deepcopy(go1)
         self.gain_object2 = copy.deepcopy(go2)
         freqs1 = self.gain_object.freq_array[0, np.arange(0, 512)]
-        freqs2 = self.gain_object2.freq_array[0, np.arange(1000, 1024)]
+        freqs2 = self.gain_object2.freq_array[0, np.arange(512, 1024)]
         self.gain_object.select(frequencies=freqs1)
         self.gain_object2.select(frequencies=freqs2)
+
+        # artificially space out frequencies
+        self.gain_object.freq_array[0, :] *= 10
+        self.gain_object2.freq_array[0, :] *= 10
         uvtest.checkWarnings(self.gain_object.__iadd__, [self.gain_object2],
                              message='Combined frequencies are not contiguous')
+        freqs1 *= 10
+        freqs2 *= 10
         freqs = np.concatenate([freqs1, freqs2])
         nt.assert_true(np.allclose(self.gain_object.freq_array[0, :], freqs,
                                     rtol=self.gain_object._freq_array.tols[0],

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -947,9 +947,9 @@ class UVCal(UVBase):
                               'it impossible to write this data out to some file types.')
 
         if this.Njones > 2:
-            pol_separation = np.diff(this.polarization_array)
-            if np.min(pol_separation) < np.max(pol_separation):
-                warnings.warn('Combined polarizations are not evenly spaced. This will '
+            jones_separation = np.diff(this.jones_array)
+            if np.min(jones_separation) < np.max(jones_separation):
+                warnings.warn('Combined Jones elements are not evenly spaced. This will '
                               'make it impossible to write this data out to some file types.')
 
         if n_axes > 0:

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -612,18 +612,22 @@ class UVCal(UVBase):
         other.check(check_extra=check_extra, run_check_acceptability=run_check_acceptability)
 
         # Check objects are compatible
-        # Note zenith_ra will not necessarily be the same if times are different.
-        # But phase_center should be the same, even if in drift (empty parameters)
         compatibility_params = ['_cal_type', '_integration_time', '_channel_width',
                                 '_telescope_name', '_gain_convention', '_x_orientation']
         if this.cal_type == 'delay':
             compatibility_params.append('_freq_range')
+        warning_params = ['_observer', '_git_hash_cal']
 
         for a in compatibility_params:
             if getattr(this, a) != getattr(other, a):
                 msg = 'UVParameter ' + \
                     a[1:] + ' does not match. Cannot combine objects.'
                 raise(ValueError(msg))
+        for a in warning_params:
+            if getattr(this, a) != getattr(other, a):
+                msg = 'UVParameter ' + \
+                    a[1:] + ' does not match. Combining anyway.'
+                warnings.warn(msg)
 
         # Build up history string
         history_update_string = ' Combined data along '
@@ -638,7 +642,8 @@ class UVCal(UVBase):
             both_freq = np.intersect1d(
                 this.freq_array[0, :], other.freq_array[0, :])
         else:
-            both_freq = []
+            # Make a non-empty array so we raise an error if other data is duplicated
+            both_freq = [0]
         both_ants = np.intersect1d(
             this.ant_array, other.ant_array)
         if len(both_jones) > 0:

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -665,6 +665,7 @@ class UVCal(UVBase):
                 history_update_string += ', time'
             else:
                 history_update_string += 'time'
+            n_axes += 1
         else:
             tnew_inds, new_times = ([], [])
 
@@ -697,32 +698,35 @@ class UVCal(UVBase):
         else:
             jnew_inds, new_jones = ([], [])
 
-        # Pad out self to accommodate new data
-        # Account for delay-type calfile having a shallow frequency axis
-        if this.cal_type == 'delay':
-            Nfreqs = 1
-        else:
-            Nfreqs = this.Nfreqs
-        # Initialize variable telling us if we can combine total_quality_array
-        # If we add antennas, we cannot
+        # Initialize tqa variables
         can_combine_tqa = True
+        if this.cal_type == 'delay':
+            Nf_tqa = 1
+        else:
+            Nf_tqa = this.Nfreqs
+
+        # Pad out self to accommodate new data
         if len(anew_inds) > 0:
             this.ant_array = np.concatenate([this.ant_array, other.ant_array[anew_inds]])
             order = np.argsort(this.ant_array)
             this.ant_array = this.ant_array[order]
-            zero_pad = np.zeros(
-                (len(anew_inds), this.Nspws, Nfreqs, this.Ntimes, this.Njones))
+            zero_pad_data = np.zeros(
+                (len(anew_inds), this.Nspws, this.quality_array.shape[2], this.Ntimes,
+                 this.Njones))
+            zero_pad_flags = np.zeros(
+                (len(anew_inds), this.Nspws, this.Nfreqs, this.Ntimes, this.Njones))
             if this.cal_type == 'delay':
-                this.delay_array = np.concatenate([this.delay_array, zero_pad], axis=0)[
+                this.delay_array = np.concatenate([this.delay_array, zero_pad_data], axis=0)[
                     order, :, :, :, :]
             else:
-                this.gain_array = np.concatenate([this.gain_array, zero_pad], axis=0)[
+                this.gain_array = np.concatenate([this.gain_array, zero_pad_data], axis=0)[
                     order, :, :, :, :]
             this.flag_array = np.concatenate([this.flag_array,
-                                              1 - zero_pad], axis=0).astype(np.bool)[
-                                                  order, :, :, :]
-            this.quality_array = np.concatenate([this.quality_array, zero_pad], axis=0)[
+                                              1 - zero_pad_flags], axis=0).astype(np.bool)[
+                                                  order, :, :, :, :]
+            this.quality_array = np.concatenate([this.quality_array, zero_pad_data], axis=0)[
                 order, :, :, :, :]
+
             # If total_quality_array exists, we set it to None and warn the user
             if this.total_quality_array is not None or other.total_quality_array is not None:
                 warnings.warn("Total quality array detected in at least one file; the "
@@ -730,8 +734,27 @@ class UVCal(UVBase):
                               "whole-array values cannot be combined when adding antennas")
                 this.total_quality_array = None
                 can_combine_tqa = False
+
+            if this.input_flag_array is not None:
+                zero_pad = np.zeros(
+                    (len(anew_inds), this.Nspws, this.Nfreqs, this.Ntimes, this.Njones))
+                this.input_flag_array = np.concatenate(
+                    [this.input_flag_array, 1 - zero_pad], axis=0).astype(np.bool)[
+                        order, :, :, :, :]
+            elif other.input_flag_array is not None:
+                zero_pad = np.zeros(
+                    (len(anew_inds), this.Nspws, this.Nfreqs, this.Ntimes, this.Njones))
+                this.input_flag_array = np.array(1 - np.zeros(
+                    (this.Nants_data, this.Nspws, this.Nfreqs, this.Ntimes,
+                     this.Njones))).astype(np.bool)
+                this.input_flag_array = np.concatenate([this.input_flag_array,
+                                                        1 - zero_pad],
+                                                       axis=0).astype(np.bool)[
+                                                           order, :, :, :, :]
+
         if len(fnew_inds) > 0:
-            # exploit the fact that quality array has the same dimensions as the main data
+            # Exploit the fact that quality array has the same dimensions as the main data
+            # Also do not need to worry about different cases for gain v. delay type
             zero_pad = np.zeros((this.quality_array.shape[0], this.Nspws, len(fnew_inds),
                                  this.Ntimes, this.Njones))
             this.freq_array = np.concatenate([this.freq_array,
@@ -749,62 +772,93 @@ class UVCal(UVBase):
                                                   :, :, order, :, :]
             this.quality_array = np.concatenate([this.quality_array, zero_pad], axis=2)[
                 :, :, order, :, :]
+
             if this.total_quality_array is not None and can_combine_tqa:
                 zero_pad = np.zeros((this.Nspws, len(fnew_inds), this.Ntimes, this.Njones))
                 this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
                                                           axis=1)[:, order, :, :]
             elif other.total_quality_array is not None and can_combine_tqa:
                 zero_pad = np.zeros((this.Nspws, len(fnew_inds), this.Ntimes, this.Njones))
-                this.total_quality_array = np.zeros((this.Nspws, Nfreqs, this.Ntimes, this.Njones))
+                this.total_quality_array = np.zeros((this.Nspws, Nf_tqa, this.Ntimes, this.Njones))
                 this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
                                                           axis=1)[:, order, :, :]
+
         if len(tnew_inds) > 0:
-            # exploit the fact that quality array has the same dimensions as the main data
-            zero_pad = np.zeros((this.quality_array.shape[0], this.Nspws,
-                                 this.quality_array.shape[2], len(tnew_inds), this.Njones))
+            # Exploit the fact that quality array has the same dimensions as the main data
+            zero_pad_data = np.zeros(
+                (this.quality_array.shape[0], this.Nspws, this.quality_array.shape[2],
+                 len(tnew_inds), this.Njones))
+            zero_pad_flags = np.zeros(
+                (this.flag_array.shape[0], this.Nspws, this.flag_array.shape[2],
+                 len(tnew_inds), this.Njones))
             this.time_array = np.concatenate([this.time_array, other.time_array[tnew_inds]])
             order = np.argsort(this.time_array)
             this.time_array = this.time_array[order]
             if this.cal_type == 'delay':
-                this.delay_array = np.concatenate([this.delay_array, zero_pad], axis=3)[
+                this.delay_array = np.concatenate([this.delay_array, zero_pad_data], axis=3)[
                     :, :, :, order, :]
             else:
-                this.gain_array = np.concatenate([this.gain_array, zero_pad], axis=3)[
+                this.gain_array = np.concatenate([this.gain_array, zero_pad_data], axis=3)[
                     :, :, :, order, :]
             this.flag_array = np.concatenate([this.flag_array,
-                                              1 - zero_pad], axis=3).astype(np.bool)[
+                                              1 - zero_pad_flags], axis=3).astype(np.bool)[
                                                   :, :, :, order, :]
-            this.qualtiy_array = np.concatenate([this.qualtiy_array, zero_pad], axis=3)[
+            this.quality_array = np.concatenate([this.quality_array, zero_pad_data], axis=3)[
                 :, :, :, order, :]
             if this.total_quality_array is not None and can_combine_tqa:
                 zero_pad = np.zeros((this.Nspws, this.quality_array.shape[2], len(tnew_inds),
                                      this.Njones))
                 this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
                                                           axis=2)[:, :, order, :]
-            elif other.total_quality_array is not None and can_comnine_tqa:
+            elif other.total_quality_array is not None and can_combine_tqa:
                 zero_pad = np.zeros((this.Nspws, this.quality_array.shape[2], len(tnew_inds),
                                      this.Njones))
-                this.total_quality_array = np.zeros((this.Nspws, Nfreqs, this.Ntimes, this.Njones))
-                this.total_qualtiy_array = np.concatenate([this.total_quality_array, zero_pad],
+                this.total_quality_array = np.zeros((this.Nspws, Nf_tqa, this.Ntimes, this.Njones))
+                this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
                                                           axis=2)[:, :, order, :]
+
+            if this.input_flag_array is not None:
+                zero_pad = np.zeros(
+                    (this.input_flag_array.shape[0], this.Nspws,
+                     this.input_flag_array.shape[2], len(tnew_inds), this.Njones))
+                this.input_flag_array = np.concatenate(
+                    [this.input_flag_array, 1 - zero_pad], axis=3).astype(np.bool)[
+                        :, :, :, order, :]
+            elif other.input_flag_array is not None:
+                zero_pad = np.zeros(
+                    (this.flag_array.shape[0], this.Nspws,
+                     this.flag_array.shape[2], len(tnew_inds), this.Njones))
+                this.input_flag_array = np.array(1 - np.zeros(
+                    (this.flag_array.shape[0], this.Nspws,
+                     this.flag_array.shape[2], this.flag_array.shape[3],
+                     this.Njones))).astype(np.bool)
+                this.input_flag_array = np.concatenate([this.input_flag_array,
+                                                        1 - zero_pad],
+                                                       axis=3).astype(np.bool)[
+                                                           :, :, :, order, :]
+
         if len(jnew_inds) > 0:
-            # exploit the fact that quality array has the same dimensions as the main data
-            zero_pad = np.zeros((this.quality_array.shape[0], this.Nspws,
-                                 this.quality_array.shape[2], this.quality_array.shape[3],
-                                 len(jnew_inds)))
+            # Exploit the fact that quality array has the same dimensions as the main data
+            zero_pad_data = np.zeros(
+                (this.quality_array.shape[0], this.Nspws, this.quality_array.shape[2],
+                 this.quality_array.shape[3], len(jnew_inds)))
+            zero_pad_flags = np.zeros(
+                (this.flag_array.shape[0], this.Nspws, this.flag_array.shape[2],
+                 this.flag_array.shape[3], len(jnew_inds)))
             this.jones_array = np.concatenate([this.jones_array, other.jones_array[jnew_inds]])
             order = np.argsort(np.abs(this.jones_array))
             if this.cal_type == 'delay':
-                this.delay_array = np.concatenate([this.delay_array, zero_pad], axis=4)[
+                this.delay_array = np.concatenate([this.delay_array, zero_pad_data], axis=4)[
                     :, :, :, :, order]
             else:
-                this.gain_array = np.concatenate([this.gain_array, zero_pad], axis=4)[
+                this.gain_array = np.concatenate([this.gain_array, zero_pad_data], axis=4)[
                     :, :, :, :, order]
             this.flag_array = np.concatenate([this.flag_array,
-                                              1 - zero_pad], axis=4).astype(np.bool)[
+                                              1 - zero_pad_flags], axis=4).astype(np.bool)[
                                                   :, :, :, :, order]
-            this.quality_array = np.concatenate([this.quality_array, zero_pad], axis=4)[
+            this.quality_array = np.concatenate([this.quality_array, zero_pad_data], axis=4)[
                 :, :, :, :, order]
+
             if this.total_quality_array is not None and can_combine_tqa:
                 zero_pad = np.zeros((this.Nspws, this.quality_array.shape[2],
                                      this.quality_array.shape[3], len(jnew_inds)))
@@ -813,9 +867,31 @@ class UVCal(UVBase):
             elif other.total_quality_array is not None and can_combine_tqa:
                 zero_pad = np.zeros((this.Nspws, this.quality_array.shape[2],
                                      this.quality_array.shape[3], len(jnew_inds)))
-                this.total_quality_array = np.zeros((this.Nspws, Nfreqs, this.Ntimes, this.Njones))
+                this.total_quality_array = np.zeros((this.Nspws, Nf_tqa, this.Ntimes, this.Njones))
                 this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
                                                           axis=3)[:, :, :, order]
+
+            if this.input_flag_array is not None:
+                zero_pad = np.zeros(
+                    (this.input_flag_array.shape[0], this.Nspws,
+                     this.input_flag_array.shape[2], this.input_flag_array.shape[3],
+                     len(jnew_inds)))
+                this.input_flag_array = np.concatenate(
+                    [this.input_flag_array, 1 - zero_pad], axis=4).astype(np.bool)[
+                        :, :, :, :, order]
+            elif other.input_flag_array is not None:
+                zero_pad = np.zeros(
+                    (this.flag_array.shape[0], this.Nspws,
+                     this.flag_array.shape[2], this.flag_array.shape[3],
+                     len(jnew_inds)))
+                this.input_flag_array = np.array(1 - np.zeros(
+                    (this.flag_array.shape[0], this.Nspws,
+                     this.flag_array.shape[2], this.flag_array.shape[3],
+                     this.Njones))).astype(np.bool)
+                this.input_flag_array = np.concatenate([this.input_flag_array,
+                                                        1 - zero_pad],
+                                                       axis=4).astype(np.bool)[
+                                                           :, :, :, :, order]
 
         # Now populate the data
         jones_t2o = np.nonzero(
@@ -827,19 +903,29 @@ class UVCal(UVBase):
         ants_t2o = np.nonzero(
             np.in1d(this.ant_array, other.ant_array))[0]
         if this.cal_type == 'delay':
-            this.delay_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
+            this.delay_array[np.ix_(ants_t2o, [0], [0], times_t2o,
                                     jones_t2o)] = other.delay_array
+            this.quality_array[np.ix_(ants_t2o, [0], [0], times_t2o,
+                                      jones_t2o)] = other.quality_array
         else:
             this.gain_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
                                    jones_t2o)] = other.gain_array
+            this.quality_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
+                                      jones_t2o)] = other.quality_array
         this.flag_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
                                jones_t2o)] = other.flag_array
-        this.quality_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
-                                  jones_t2o)] = other.quality_array
         if this.total_quality_array is not None:
             if other.total_quality_array is not None:
-                this.total_quality_array[np.ix_([0], freqs_t2o, times_t2o,
-                                                jones_t2o)] = other.total_quality_array
+                if this.cal_type == 'delay':
+                    this.total_quality_array[np.ix_([0], [0], times_t2o,
+                                                    jones_t2o)] = other.total_quality_array
+                else:
+                    this.total_quality_array[np.ix_([0], freqs_t2o, times_t2o,
+                                                    jones_t2o)] = other.total_quality_array
+        if this.input_flag_array is not None:
+            if other.input_flag_array is not None:
+                this.input_flag_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
+                                              jones_t2o)] = other.input_flag_array
 
         # Update N parameters (e.g. Npols)
         this.Njones = this.jones_array.shape[0]

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -583,3 +583,299 @@ class UVCal(UVBase):
                                   run_check_acceptability=run_check_acceptability,
                                   clobber=clobber)
         del(calfits_obj)
+
+    def __add__(self, other, run_check=True, check_extra=True,
+                run_check_acceptability=True, inplace=False)
+        """
+        Combine two UVCal objects. Objects can be added along antenna, frequency,
+        time, and/or Jones axis.
+
+        Args:
+            other: Another UVCal object which will be added to self.
+            run_check: Option to check for the existence and proper shapes of
+                parameters after combining objects. Default is True.
+            check_extra: Option to check optional parameters as well as
+                required ones. Default is True.
+            run_check_acceptability: Option to check acceptable range of the values of
+                parameters after combining objects. Default is True.
+            inplace: Overwrite self as we go, otherwise create a third object
+                as the sum of the two (default).
+        """
+        if inplace:
+            this = self
+        else:
+            this = copy.deepcopy(self)
+        # Check that both objects are UVCal and valid
+        this.check(check_extra=check_extra, run_check_acceptability=run_check_acceptability)
+        if not isinstance(other, this.__class__):
+            raise(ValueError('Only UVCal objects can be added to a UVCal object'))
+        other.check(check_extra=check_extra, run_check_acceptability=run_check_acceptability)
+
+        # Check objects are compatible
+        # Note zenith_ra will not necessarily be the same if times are different.
+        # But phase_center should be the same, even if in drift (empty parameters)
+        compatibility_params = ['_cal_type', '_integration_time', '_channel_width',
+                                '_telescope_name', '_gain_convention', '_x_orientation']
+        if this.cal_type == 'delay':
+            compatibility_params.append('_freq_range')
+
+        for a in compatibility_params:
+            if getattr(this, a) != getattr(other, a):
+                msg = 'UVParameter ' + \
+                    a[1:] + ' does not match. Cannot combine objects.'
+                raise(ValueError(msg))
+
+        # Error out on unknown-type calfiles
+        if this.cal_type == 'unknown':
+            raise(ValueError('UVCal objects of unknown type cannot be combined'))
+
+        # Build up history string
+        history_update_string = ' Combined data along '
+        n_axes = 0
+
+        # Check we don't have overlapping data
+        both_jones = np.intersect1d(
+            this.jones_array, other.jones_array)
+        both_times = np.intersect1d(
+            this.time_array, other.time_array)
+        if this.cal_type == 'gain':
+            both_freq = np.intersect1d(
+                this.freq_array[0, :], other.freq_array[0, :])
+        else:
+            both_freq = []
+        both_ants = np.intersect1d(
+            this.ant_array, other.ant_array)
+        if len(both_jones) > 0:
+            if len(both_times) > 0:
+                if len(both_freq) > 0:
+                    if len(both_ants) > 0:
+                        raise(ValueError('These objects have overlapping data and'
+                                         ' cannot be combined.'))
+
+        temp = np.nonzero(~np.in1d(other.ant_array, this.ant_array))[0]
+        if len(temp) > 0:
+            anew_inds = temp
+            new_ants = other.ant_array[temp]
+            history_update_string += 'antenna'
+            n_axes += 1
+        else:
+            anew_inds, new_ants = ([], [])
+
+        temp = np.nonzero(~np.in1d(other.time_array, this.time_array))[0]
+        if len(temp) > 0:
+            tnew_inds = temp
+            new_times = other.time_array[temp]
+            if n_axes > 0:
+                history_update_string += ', time'
+            else:
+                history_update_string += 'time'
+        else:
+            tnew_inds, new_times = ([], [])
+
+        if this.cal_type == 'gain':
+            temp = np.nonzero(
+                ~np.in1d(other.freq_array[0, :], this.freq_array[0, :]))[0]
+            if len(temp) > 0:
+                fnew_inds = temp
+                new_freqs = other.freq_array[0, temp]
+                if n_axes > 0:
+                    history_update_string += ', frequency'
+                else:
+                    history_update_string += 'frequency'
+                n_axes += 1
+            else:
+                fnew_inds, new_freqs = ([], [])
+        else:
+            fnew_inds, new_freqs = ([], [])
+
+        temp = np.nonzero(~np.in1d(other.jones_array,
+                                   this.jones_array))[0]
+        if len(temp) > 0:
+            jnew_inds = temp
+            new_jones = other.jones_array[temp]
+            if n_axes > 0:
+                history_update_string += ', jones'
+            else:
+                history_update_string += 'jones'
+            n_axes += 1
+        else:
+            jnew_inds, new_jones = ([], [])
+
+        # Pad out self to accommodate new data
+        # Account for delay-type calfile having a shallow frequency axis
+        if this.delay_type == 'delay':
+            Nfreqs = 1
+            data_array = this.delay_array
+            other_data_array = other.delay_array
+        else:
+            Nfreqs = this.Nfreqs
+            data_array = this.gains_array
+            other_data_array = other.gains_array
+        if len(anew_inds) > 0:
+            this.ant_array = np.concatenate([this.ant_array,
+                                             this.ant_array[fnew_inds]], axis=1)
+            order = np.argsort(this.ant_array)
+            this.ant_array = this.ant_array[order]
+            zero_pad = np.zeros(
+                (len(anew_inds), this.Nspws, Nfreqs, this.time, this.Njones))
+            data_array = np.concatenate([data_array, zero_pad], axis=0)[
+                order, :, :, :, :]
+            this.flag_array = np.concatenate([this.flag_array,
+                                              1 - zero_pad], axis=0).astype(np.bool)[order, :, :, :]
+            this.quality_array = np.concatenate([this.quality_array, zero_pad], axis=0)[
+                order, :, :, :, :]
+            # If total_quality_array exists, we set it to None and warn the user
+            if this.total_qualtiy_array is not None or other.total_quality_array is not None:
+                warnings.warn("Total quality array detected in at least one file; the "
+                              "array in the new object will be set to 'None' because "
+                              "whole-array values cannot be combined when adding antennas")
+                this.total_quality_array = None
+        if len(fnew_inds) > 0:
+            zero_pad = np.zeros((data_array.shape[0], this.Nspws, len(fnew_inds),
+                                 this.Ntimes, this.Njones))
+            this.freq_array = np.concatenate([this.freq_array,
+                                              other.freq_array[:, fnew_inds]], axis=1)
+            order = np.argsort(this.freq_array[0, :])
+            this.freq_array = this.freq_array[:, order]
+            data_array = np.concatenate([data_array, zero_pad], axis=2)[:, :, order, :, :]
+            this.flag_array = np.concatenate([this.flag_array,
+                                              1 - zero_pad], axis=2).astype(np.bool)[
+                                                  :, :, order, :, :]
+            this.quality_array = np.concatenate([this.quality_array, zero_pad], axis=2)[
+                :, :, order, :, :]
+            if this.total_quality_array is not None:
+                zero_pad = np.zeros((this.Nspws, len(fnew_inds), this.Ntimes, this.Njones))
+                this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
+                                                          axis=1)[:, order, :, :]
+            elif other.total_quality_array is not None:
+                zero_pad = np.zeros((this.Nspws, len(fnew_inds), this.Ntimes, this.Njones))
+                this.total_quality_array = np.zeros((this.Nspws, Nfreqs, this.Ntimes, this.Njones))
+                this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
+                                                          axis=1)[:, order, :, :]
+        if len(tnew_inds) > 0:
+            zero_pad = np.zeros((data_array.shape[0], this.Nspws,
+                                 data_array.shape[2], len(tnew_inds), this.Njones))
+            this.time_array = np.concatenate([this.time_array, other.time_array[tnew_inds]])
+            order = np.argsort(this.time_array)
+            this.time_array = this.time_array[order]
+            data_array = np.concatenate([data_array, zero_pad], axis=3)[:, :, :, order, :]
+            this.flag_array = np.concatenate([this.flag_array,
+                                              1 - zero_pad], axis=3).astype(np.bool)[
+                                                  :, :, :, order, :]
+            this.qualtiy_array = np.concatenate([this.qualtiy_array, zero_pad], axis=3)[
+                :, :, :, order, :]
+            if this.total_quality_array is not None:
+                zero_pad = np.zeros((this.Nspws, data_array.shape[2], len(tnew_inds), this.Njones))
+                this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
+                                                          axis=2)[:, :, order, :]
+            elif other.total_quality_array is not None:
+                zero_pad = np.zeros((this.Nspws, data_array.shape[2], len(tnew_inds), this.Njones))
+                this.total_quality_array = np.zeros((this.Nspws, Nfreqs, this.Ntimes, this.Njones))
+                this.total_qualtiy_array = np.concatenate([this.total_quality_array, zero_pad],
+                                                          axis=2)[:, :, order, :]
+        if len(jnew_inds) > 0:
+            zero_pad = np.zeros((data_array.shape[0], this.Nspws,
+                                 data_array.shape[2], data_array.shape[3], len(jnew_inds)))
+            this.jones_array = np.concatenate([this.jones_array, other.jones_array[jnew_inds]])
+            order = np.argsort(np.abs(this.jones_array))
+            data_array = np.concatenate([data_array, zero_pad], axis=4)[:, :, :, :, order]
+            this.flag_array = np.concatenate([this.flag_array,
+                                              1 - zero_pad], axis=4).astype(np.bool)[
+                                                  :, :, :, :, order]
+            this.quality_array = np.concatenate([this.quality_array, zero_pad], axis=4)[
+                :, :, :, :, order]
+            if this.total_quality_array is not None:
+                zero_pad = np.zeros((this.Nspws, data_array.shape[2], data_array.shape[3],
+                                     len(jnew_inds)))
+                this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
+                                                          axis=3)[:, :, :, order]
+            elif other.total_quality_array is not None:
+                zero_pad = np.zeros((this.Nspws, data_array.shape[2], data_array.shape[3],
+                                     len(jnew_inds)))
+                this.total_quality_array = np.zeros((this.Nspws, Nfreqs, this.Ntimes, this.Njones))
+                this.total_quality_array = np.concatenate([this.total_quality_array, zero_pad],
+                                                          axis=3)[:, :, :, order]
+
+        # Now populate the data
+        jones_t2o = np.nonzero(
+            np.in1d(this.jones_array, other.jones_array))[0]
+        times_t2o = np.nonzero(
+            np.in1d(this.times_array, other.times_array))[0]
+        freqs_t2o = np.nonzero(
+            np.in1d(this.freq_array[0, :], other.freq_array[0, :]))[0]
+        ants_t20 = np.nonzero(
+            np.in1d(this.ant_array, other.ant_array))[0]
+        data_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
+                          jones_t2o)] = other_data_array
+        this.flag_array[np.ix_(ants_t2o, [0], freqs_t2o, times_t2o,
+                               jones_t2o)] = other.flag_array
+        this.quality_array[np.ix_(ants_t2p, [0], freqs_t2o, times_t2o,
+                                  jones_t2o)] = other.quality_array
+        if this.total_quality_array is not None:
+            if other.total_quality_array is not None:
+                this.total_quality_array[np.ix_([0], freqs_t2o, times_t2o,
+                                                jones_t2o)] = other.total_quality_array
+
+        # Update N parameters (e.g. Npols)
+        this.Njones = this.jones_array.shape[0]
+        this.Ntimes = this.time_array.shape[0]
+        if this.cal_type == 'gains':
+            this.Nfreqs = this.freq_array.shape[1]
+        this.Nants_data = len(
+            np.unique(this.ant_1_array.tolist() + this.ant_2_array.tolist()))
+
+        # Check specific requirements
+        if this.cal_type == 'gains' and this.Nfreqs > 1:
+            freq_separation = np.diff(this.freq_array[0, :])
+            if not np.isclose(np.min(freq_separation), np.max(freq_separation),
+                              rtol=this._freq_array.tols[0], atol=this._freq_array.tols[1]):
+                warnings.warn('Combined frequencies are not evenly spaced. This will '
+                              'make it impossible to write this data out to some file types.')
+            elif np.max(freq_separation) > this.channel_width:
+                warnings.warn('Combined frequencies are not contiguous. This will make '
+                              'it impossible to write this data out to some file types.')
+
+        if this.Njones > 2:
+            pol_separation = np.diff(this.polarization_array)
+            if np.min(pol_separation) < np.max(pol_separation):
+                warnings.warn('Combined polarizations are not evenly spaced. This will '
+                              'make it impossible to write this data out to some file types.')
+
+        if n_axes > 0:
+            history_update_string += ' axis using pyuvdata.'
+            this.history += history_update_string
+
+        other_hist_words = other.history.split(' ')
+        add_hist = ''
+        for i, word in enumerate(other_hist_words):
+            if word not in this.history:
+                add_hist += ' ' + word
+                keep_going = (i + 1 < len(other_hist_words))
+                while keep_going:
+                    if ((other_hist_words[i + 1] is ' ') or
+                            (other_hist_words[i + 1] not in this.history)):
+                        add_hist += ' ' + other_hist_words[i + 1]
+                        del(other_hist_words[i + 1])
+                        keep_going = (i + 1 < len(other_hist_words))
+                    else:
+                        keep_going = False
+        this.history += add_hist
+
+        # Check final object is self-consistent
+        if run_check:
+            this.check(check_extra=check_extra,
+                       run_check_acceptability=run_check_acceptability)
+
+        if not inplace:
+            return this
+
+    def __iadd__(self, other):
+        """
+        In place add.
+
+        Args:
+            other: Another UVData object which will be added to self.
+        """
+        self.__add__(other, inplace=True)
+        return self
+

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -669,6 +669,7 @@ class UVCal(UVBase):
         else:
             tnew_inds, new_times = ([], [])
 
+        # adding along frequency axis is not supported for delay-type cal files
         if this.cal_type == 'gain':
             temp = np.nonzero(
                 ~np.in1d(other.freq_array[0, :], this.freq_array[0, :]))[0]
@@ -761,12 +762,8 @@ class UVCal(UVBase):
                                               other.freq_array[:, fnew_inds]], axis=1)
             order = np.argsort(this.freq_array[0, :])
             this.freq_array = this.freq_array[:, order]
-            if this.cal_type == 'delay':
-                this.delay_array = np.concatenate([this.delay_array, zero_pad], axis=2)[
-                    :, :, order, :, :]
-            else:
-                this.gain_array = np.concatenate([this.gain_array, zero_pad], axis=2)[
-                    :, :, order, :, :]
+            this.gain_array = np.concatenate([this.gain_array, zero_pad], axis=2)[
+                :, :, order, :, :]
             this.flag_array = np.concatenate([this.flag_array,
                                               1 - zero_pad], axis=2).astype(np.bool)[
                                                   :, :, order, :, :]


### PR DESCRIPTION
This PR adds an `__add__` method to the UVCal object and addresses Issue #164. The general structure closely follows the `__add__` method of the UVData object. This method allows the user to combine two different UVCal objects of the same `cal_type` along the antenna, frequency, time, or Jones axis. Special care is taken to appropriately handle the optional parameters `total_quality_array` and `input_flag_array`.