### PR TITLE
Make uvcal select function include total_quality_array

### DIFF
--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -785,15 +785,13 @@ class TestUVCalAddGain(object):
                                    atol=self.gain_object._total_quality_array.tols[1]))
 
         # test for when total_quality_array is present in second file but not first
-        ### XXX: Select function does not properly down-select total_quality_array.
-        ### XXX: The next line is not needed once this is fixed
-        self.gain_object.total_quality_array = None
         self.gain_object.select(frequencies=freqs1)
         tqa = np.zeros(
             self.gain_object._total_quality_array.expected_shape(self.gain_object))
         tqa2 = np.ones(
             self.gain_object2._total_quality_array.expected_shape(self.gain_object2))
         tot_tqa = np.concatenate([tqa, tqa2], axis=1)
+        self.gain_object.total_quality_array = None
         self.gain_object2.total_quality_array = tqa2
         self.gain_object += self.gain_object2
         nt.assert_true(np.allclose(self.gain_object.total_quality_array, tot_tqa,
@@ -801,8 +799,6 @@ class TestUVCalAddGain(object):
                                    atol=self.gain_object._total_quality_array.tols[1]))
 
         # test for when total_quality_array is present in both
-        ### XXX: See above
-        self.gain_object.total_quality_array = None
         self.gain_object.select(frequencies=freqs1)
         tqa = np.ones(
             self.gain_object._total_quality_array.expected_shape(self.gain_object))
@@ -847,15 +843,13 @@ class TestUVCalAddGain(object):
                                    atol=self.gain_object._total_quality_array.tols[1]))
 
         # test for when total_quality_array is present in second file but not first
-        ### XXX: Select function does not properly down-select total_quality_array.
-        ### XXX: The next line is not needed once this is fixed
-        self.gain_object.total_quality_array = None
         self.gain_object.select(times=times1)
         tqa = np.zeros(
             self.gain_object._total_quality_array.expected_shape(self.gain_object))
         tqa2 = np.ones(
             self.gain_object2._total_quality_array.expected_shape(self.gain_object2))
         tot_tqa = np.concatenate([tqa, tqa2], axis=2)
+        self.gain_object.total_quality_array = None
         self.gain_object2.total_quality_array = tqa2
         self.gain_object += self.gain_object2
         nt.assert_true(np.allclose(self.gain_object.total_quality_array, tot_tqa,
@@ -863,8 +857,6 @@ class TestUVCalAddGain(object):
                                    atol=self.gain_object._total_quality_array.tols[1]))
 
         # test for when total_quality_array is present in both
-        ### XXX: See above
-        self.gain_object.total_quality_array = None
         self.gain_object.select(times=times1)
         tqa = np.ones(
             self.gain_object._total_quality_array.expected_shape(self.gain_object))
@@ -1155,15 +1147,13 @@ class TestUVCalAddDelay(object):
                                    atol=self.delay_object._total_quality_array.tols[1]))
 
         # test for when total_quality_array is present in second file but not first
-        ### XXX: Select function does not properly down-select total_quality_array.
-        ### XXX: The next line is not needed once this is fixed
-        self.delay_object.total_quality_array = None
         self.delay_object.select(times=times1)
         tqa = np.zeros(
             self.delay_object._total_quality_array.expected_shape(self.delay_object))
         tqa2 = np.ones(
             self.delay_object2._total_quality_array.expected_shape(self.delay_object2))
         tot_tqa = np.concatenate([tqa, tqa2], axis=2)
+        self.delay_object.total_quality_array = None
         self.delay_object2.total_quality_array = tqa2
         self.delay_object += self.delay_object2
         nt.assert_true(np.allclose(self.delay_object.total_quality_array, tot_tqa,
@@ -1171,8 +1161,6 @@ class TestUVCalAddDelay(object):
                                    atol=self.delay_object._total_quality_array.tols[1]))
 
         # test for when total_quality_array is present in both
-        ### XXX: See above
-        self.delay_object.total_quality_array = None
         self.delay_object.select(times=times1)
         tqa = np.ones(
             self.delay_object._total_quality_array.expected_shape(self.delay_object))
@@ -1188,8 +1176,6 @@ class TestUVCalAddDelay(object):
                                    atol=self.delay_object._total_quality_array.tols[1]))
 
         # test for when input_flag_array is present in first file but not second
-        ### XXX: See above
-        self.delay_object.total_quality_array = None
         self.delay_object.select(times=times1)
         ifa = np.zeros(
             self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)
@@ -1202,8 +1188,6 @@ class TestUVCalAddDelay(object):
         nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
 
         # test for when input_flag_array is present in second file but not first
-        ### XXX: See above
-        self.delay_object.total_quality_array = None
         self.delay_object.select(times=times1)
         ifa = np.ones(
             self.delay_object._input_flag_array.expected_shape(self.delay_object)).astype(np.bool)

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -244,6 +244,13 @@ class TestUVCalSelectGain(object):
         write_file_calfits = os.path.join(DATA_PATH, 'test/select_test.calfits')
         status = self.gain_object2.write_calfits(write_file_calfits, clobber=True)
 
+        # check that total_quality_array is handled properly when present
+        self.gain_object.total_quality_array = np.zeros(
+            self.gain_object._total_quality_array.expected_shape(self.gain_object))
+        uvtest.checkWarnings(self.gain_object.select, [], {'antenna_names': ant_names, 'inplace':True},
+                             message='Cannot preserve total_quality_array')
+        nt.assert_equal(self.gain_object.total_quality_array, None)
+
     def test_select_times(self):
         # add another time to allow for better testing of selections
         new_time = np.max(self.gain_object.time_array) + self.gain_object.integration_time
@@ -258,6 +265,8 @@ class TestUVCalSelectGain(object):
         self.gain_object.quality_array = np.concatenate((self.gain_object.quality_array,
                                                          self.gain_object.quality_array[:, :, :, [-1], :]),
                                                         axis=3)
+        self.gain_object.total_quality_array = np.zeros(
+            self.gain_object._total_quality_array.expected_shape(self.gain_object))
         nt.assert_true(self.gain_object.check())
         self.gain_object2 = copy.deepcopy(self.gain_object)
 
@@ -296,6 +305,12 @@ class TestUVCalSelectGain(object):
         old_history = self.gain_object.history
         freqs_to_keep = self.gain_object.freq_array[0, np.arange(73, 944)]
 
+        # add dummy total_quality_array
+        self.gain_object.total_quality_array = np.zeros(
+            self.gain_object._total_quality_array.expected_shape(self.gain_object))
+        self.gain_object2.total_quality_array = np.zeros(
+            self.gain_object2._total_quality_array.expected_shape(self.gain_object2))
+
         self.gain_object2.select(frequencies=freqs_to_keep)
 
         nt.assert_equal(len(freqs_to_keep), self.gain_object2.Nfreqs)
@@ -326,6 +341,12 @@ class TestUVCalSelectGain(object):
     def test_select_freq_chans(self):
         old_history = self.gain_object.history
         chans_to_keep = np.arange(73, 944)
+
+        # add dummy total_quality_array
+        self.gain_object.total_quality_array = np.zeros(
+            self.gain_object._total_quality_array.expected_shape(self.gain_object))
+        self.gain_object2.total_quality_array = np.zeros(
+            self.gain_object2._total_quality_array.expected_shape(self.gain_object2))
 
         self.gain_object2.select(freq_chans=chans_to_keep)
 
@@ -366,6 +387,10 @@ class TestUVCalSelectGain(object):
             self.gain_object.quality_array = np.concatenate((self.gain_object.quality_array,
                                                              self.gain_object.quality_array[:, :, :, :, [-1]]),
                                                             axis=4)
+        # add dummy total_quality_array
+        self.gain_object.total_quality_array = np.zeros(
+            self.gain_object._total_quality_array.expected_shape(self.gain_object))
+
         nt.assert_true(self.gain_object.check())
         self.gain_object2 = copy.deepcopy(self.gain_object)
 
@@ -489,6 +514,13 @@ class TestUVCalSelectDelay(object):
         nt.assert_raises(ValueError, self.delay_object.select,
                          antenna_nums=ants_to_keep, antenna_names=ant_names)
 
+        # check that total_quality_array is handled properly when present
+        self.delay_object.total_quality_array = np.zeros(
+            self.delay_object._total_quality_array.expected_shape(self.delay_object))
+        uvtest.checkWarnings(self.delay_object.select, [], {'antenna_names': ant_names, 'inplace':True},
+                             message='Cannot preserve total_quality_array')
+        nt.assert_equal(self.delay_object.total_quality_array, None)
+
     def test_select_times(self):
         # add another time to allow for better testing of selections
         new_time = np.max(self.delay_object.time_array) + self.delay_object.integration_time
@@ -506,6 +538,8 @@ class TestUVCalSelectDelay(object):
         self.delay_object.quality_array = np.concatenate((self.delay_object.quality_array,
                                                           self.delay_object.quality_array[:, :, :, [-1], :]),
                                                          axis=3)
+        self.delay_object.total_quality_array = np.zeros(
+            self.delay_object._total_quality_array.expected_shape(self.delay_object))
         nt.assert_true(self.delay_object.check())
         self.delay_object2 = copy.deepcopy(self.delay_object)
 
@@ -538,6 +572,12 @@ class TestUVCalSelectDelay(object):
         old_history = self.delay_object.history
         freqs_to_keep = self.delay_object.freq_array[0, np.arange(73, 944)]
 
+        # add dummy total_quality_array
+        self.delay_object.total_quality_array = np.zeros(
+            self.delay_object._total_quality_array.expected_shape(self.delay_object))
+        self.delay_object2.total_quality_array = np.zeros(
+            self.delay_object2._total_quality_array.expected_shape(self.delay_object2))
+
         self.delay_object2.select(frequencies=freqs_to_keep)
 
         nt.assert_equal(len(freqs_to_keep), self.delay_object2.Nfreqs)
@@ -562,6 +602,12 @@ class TestUVCalSelectDelay(object):
     def test_select_freq_chans(self):
         old_history = self.delay_object.history
         chans_to_keep = np.arange(73, 944)
+
+        # add dummy total_quality_array
+        self.delay_object.total_quality_array = np.zeros(
+            self.delay_object._total_quality_array.expected_shape(self.delay_object))
+        self.delay_object2.total_quality_array = np.zeros(
+            self.delay_object2._total_quality_array.expected_shape(self.delay_object2))
 
         self.delay_object2.select(freq_chans=chans_to_keep)
 
@@ -605,6 +651,9 @@ class TestUVCalSelectDelay(object):
             self.delay_object.quality_array = np.concatenate((self.delay_object.quality_array,
                                                               self.delay_object.quality_array[:, :, :, :, [-1]]),
                                                              axis=4)
+        # add dummy total_quality_array
+        self.delay_object.total_quality_array = np.zeros(
+            self.delay_object._total_quality_array.expected_shape(self.delay_object))
         nt.assert_true(self.delay_object.check())
         self.delay_object2 = copy.deepcopy(self.delay_object)
 

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -337,6 +337,11 @@ class UVCal(UVBase):
             if cal_object.input_flag_array is not None:
                 cal_object.input_flag_array = cal_object.input_flag_array[ant_inds, :, :, :, :]
 
+            if cal_object.total_quality_array is not None:
+                warnings.warn('Cannot preserve total_quality_array when changing '
+                              'number of antennas; discarding')
+                cal_object.total_quality_array = None
+
         if times is not None:
             times = uvutils.get_iterable(times)
             if n_selects > 0:
@@ -373,6 +378,9 @@ class UVCal(UVBase):
 
             if cal_object.input_flag_array is not None:
                 cal_object.input_flag_array = cal_object.input_flag_array[:, :, :, time_inds, :]
+
+            if cal_object.total_quality_array is not None:
+                cal_object.total_quality_array = cal_object.total_quality_array[:, :, time_inds, :]
 
         if freq_chans is not None:
             freq_chans = uvutils.get_iterable(freq_chans)
@@ -422,6 +430,12 @@ class UVCal(UVBase):
             if cal_object.input_flag_array is not None:
                 cal_object.input_flag_array = cal_object.input_flag_array[:, :, freq_inds, :, :]
 
+            if cal_object.cal_type == 'delay':
+                pass
+            else:
+                if cal_object.total_quality_array is not None:
+                    cal_object.total_quality_array = cal_object.total_quality_array[:, freq_inds, :, :]
+
         if jones is not None:
             jones = uvutils.get_iterable(jones)
             if n_selects > 0:
@@ -455,6 +469,9 @@ class UVCal(UVBase):
 
             if cal_object.input_flag_array is not None:
                 cal_object.input_flag_array = cal_object.input_flag_array[:, :, :, :, jones_inds]
+
+            if cal_object.total_quality_array is not None:
+                cal_object.total_quality_array = cal_object.total_quality_array[:, :, :, jones_inds]
 
         history_update_string += ' using pyuvdata.'
         cal_object.history = cal_object.history + history_update_string


### PR DESCRIPTION
This PR addresses Issue #210, which was where the total_quality_array was not handled properly by the select function if it was present. This has been fixed, and accompanying tests have been added.