### PR TITLE
Make spw_array backwards compatible

### DIFF
--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -438,8 +438,12 @@ class CALFITS(UVCal):
 
             # add this for backwards compatibility when the spw CRVAL wasn't recorded
             try:
-                # subtract 1 to be zero-indexed
-                self.spw_array = uvutils.fits_gethduaxis(F[0], ax_spw, strict_fits=strict_fits) - 1
+                spw_array = uvutils.fits_gethduaxis(F[0], ax_spw, strict_fits=strict_fits)
+                if spw_array[0] == 0:
+                    self.spw_array = spw_array
+                else:
+                    # subtract 1 to be zero-indexed
+                    self.spw_array = spw_array - 1
             except(KeyError):
                 if not strict_fits:
                     _warn_oldcalfits(filename)

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -392,8 +392,14 @@ class CALFITS(UVCal):
             self.Nspws = hdr['NAXIS5']
             # add this for backwards compatibility when the spw CRVAL wasn't recorded
             try:
-                # subtract 1 to be zero-indexed
-                self.spw_array = uvutils.fits_gethduaxis(F[0], 5, strict_fits=strict_fits) - 1
+                spw_array = uvutils.fits_gethduaxis(F[0], 5, strict_fits=strict_fits) - 1
+                if spw_array[0] == 0:
+                    # XXX: backwards compatibility: if array is already (erroneously) zero-
+                    #      indexed, do nothing
+                    self.spw_array = spw_array
+                else:
+                    # subtract 1 to be zero-indexed
+                    self.spw_array = uvutils.fits_gethduaxis(F[0], 5, strict_fits=strict_fits) - 1
             except(KeyError):
                 if not strict_fits:
                     _warn_oldcalfits(filename)
@@ -440,6 +446,8 @@ class CALFITS(UVCal):
             try:
                 spw_array = uvutils.fits_gethduaxis(F[0], ax_spw, strict_fits=strict_fits)
                 if spw_array[0] == 0:
+                    # XXX: backwards compatibility: if array is already (erroneously) zero-
+                    #      indexed, do nothing
                     self.spw_array = spw_array
                 else:
                     # subtract 1 to be zero-indexed


### PR DESCRIPTION
In the calfits files generated as part of IDR2, the `spw_array` was erroneously 0-indexed (as opposed to 1-indexed), so the conversion from a 1-indexed array as required by the FITS format means `self.spw_array == array([-1])`. A check is performed when reading in files, and 1 is only subtracted if the array is found to be 1-indexed. Though this should not be an issue going forward, it does allow users to read in the calfits files generated as part of IDR2.