### PR TITLE
Add method to generate 'rotated ECEF' coordinates where x-axis goes through a particular meridian

### DIFF
--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -135,13 +135,17 @@ def test_mwa_ecef_conversion():
 
     # The STABXYZ coordinates are defined with X through the local meridian,
     # so rotate back to the prime meridian
-    ecef_xyz = uvutils.ECEF_from_rotECEF(xyz, lon)
+    new_xyz = uvutils.ECEF_from_rotECEF(xyz, lon)
     # add in array center to get real ECEF
-    ecef_xyz = (ecef_xyz.T + arrcent).T
+    ecef_xyz = (new_xyz.T + arrcent).T
 
     enu = uvutils.ENU_from_ECEF(ecef_xyz, lat, lon, alt)
 
     nt.assert_true(np.allclose(enu, enh))
+
+    # test other direction of ECEF rotation
+    rot_xyz = uvutils.rotECEF_from_ECEF(new_xyz, lon)
+    nt.assert_true(np.allclose(rot_xyz, xyz))
 
 
 def test_pol_funcs():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -90,6 +90,45 @@ def XYZ_from_LatLonAlt(latitude, longitude, altitude):
     return xyz
 
 
+def rotECEF_from_ECEF(xyz, longitude):
+    """
+    Calculate a rotated ECEF from ECEF such that the x-axis goes through the
+    specified longitude.
+
+    Miriad (and maybe uvfits) expect antenna positions in this frame
+    (with longitude of the array center/telescope location)
+
+    Args:
+        xyz: numpy array, shape (3, Npts), with ECEF x,y,z coordinates
+        longitude: longitude in radians to rotate coordinates to (usually the array center/telescope location)
+    Returns:
+        numpy array, shape (3, Npts), with rotated ECEF coordinates
+    """
+    angle = -1 * longitude
+    rot_matrix = np.array([[np.cos(angle), -1 * np.sin(angle), 0],
+                           [np.sin(angle), np.cos(angle), 0],
+                           [0, 0, 1]])
+    return rot_matrix.dot(xyz.T).T
+
+
+def ECEF_from_rotECEF(xyz, longitude):
+    """
+    Calculate ECEF from a rotated ECEF such that the x-axis goes through the
+    specified longitude. (Inverse of rotECEF_from_ECEF)
+
+    Args:
+        xyz: numpy array, shape (3, Npts), with rotated ECEF x,y,z coordinates
+        longitude: longitude in radians to rotate coordinates to (usually the array center/telescope location)
+    Returns:
+        numpy array, shape (3, Npts), with ECEF coordinates
+    """
+    angle = longitude
+    rot_matrix = np.array([[np.cos(angle), -1 * np.sin(angle), 0],
+                           [np.sin(angle), np.cos(angle), 0],
+                           [0, 0, 1]])
+    return rot_matrix.dot(xyz)
+
+
 def ENU_from_ECEF(xyz, latitude, longitude, altitude):
     """
     Calculate local ENU (east, north, up) coordinates from ECEF coordinates.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -108,7 +108,7 @@ def rotECEF_from_ECEF(xyz, longitude):
     rot_matrix = np.array([[np.cos(angle), -1 * np.sin(angle), 0],
                            [np.sin(angle), np.cos(angle), 0],
                            [0, 0, 1]])
-    return rot_matrix.dot(xyz.T).T
+    return rot_matrix.dot(xyz)
 
 
 def ECEF_from_rotECEF(xyz, longitude):


### PR DESCRIPTION
These utility functions are needed to properly support Miriad and uvfits formats -- changes to those codes will be in another PR. It's also needed to allow the correlator to write antenna positions into Miriad files properly.

We do have some nice ground truth for testing -- comparing the uvfits locations from an MWA Cotter file and the antenna positions from MWA_tools.