### PR TITLE
Add an aipy version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ for aipy (```conda install -c conda-forge aipy```).
 * scipy
 * astropy >= 1.2
 * pyephem
-* aipy
+* aipy >= 2.1.5
 * casacore-python (for CASA measurement set reading functionality)
 
 ## Install pyuvdata

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup_args = {
     'scripts': glob.glob('scripts/*'),
     'version': version.version,
     'include_package_data': True,
-    'install_requires': ['numpy>=1.10', 'scipy', 'astropy>=1.2', 'pyephem', 'aipy'],
+    'install_requires': ['numpy>=1.10', 'scipy', 'astropy>=1.2', 'pyephem', 'aipy>=2.1.5'],
     'classifiers': ['Development Status :: 5 - Production/Stable',
                     'Intended Audience :: Science/Research',
                     'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
This addresses the fact that we now require a higher aipy version in order to support the new miriad antenna names encoding.