### PR TITLE
MIRIAD antdiam keyword

### DIFF
--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -58,7 +58,7 @@ class Miriad(UVData):
                                     'timesys', 'xorient', 'cnt', 'ra', 'dec',
                                     'lst', 'pol', 'nants', 'antnames', 'nblts',
                                     'ntimes', 'nbls', 'sfreq', 'epoch',
-                                    'antpos', 'antnums', 'degpdy', 'diameter'
+                                    'antpos', 'antnums', 'degpdy', 'antdiam'
                                     ]
         # list of miriad variables not read, but also not interesting
         # NB: nspect (I think) is number of spectral windows, will want one day
@@ -417,7 +417,7 @@ class Miriad(UVData):
 
         # check for antenna diameters
         try:
-            self.antenna_diameters = uv['diameter']
+            self.antenna_diameters = uv['antdiam']
         except(KeyError):
             pass
 
@@ -738,8 +738,8 @@ class Miriad(UVData):
             uv['timesys'] = self.timesys
 
         if self.antenna_diameters is not None:
-            uv.add_var('diameter', 'd')
-            uv['diameter'] = self.antenna_diameters
+            uv.add_var('antdiam', 'd')
+            uv['antdiam'] = self.antenna_diameters
 
         # other extra keywords
         # set up dictionaries to map common python types to miriad types

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -419,7 +419,11 @@ class Miriad(UVData):
         try:
             self.antenna_diameters = uv['antdiam']
         except(KeyError):
-            pass
+            # backwards compatibility for when keyword was 'diameter'
+            try:
+                self.antenna_diameters = uv['diameter']
+            except(KeyError):
+                pass
 
         # form up a grid which indexes time and baselines along the 'long'
         # axis of the visdata array
@@ -665,6 +669,9 @@ class Miriad(UVData):
         if self.x_orientation is not None:
             uv.add_var('xorient', 'a')
             uv['xorient'] = self.x_orientation
+        if self.antenna_diameters is not None:
+            uv.add_var('antdiam', 'd')
+            uv['antdiam'] = self.antenna_diameters
 
         # Miriad has no way to keep track of antenna numbers, so the antenna
         # numbers are simply the index for each antenna in any array that
@@ -736,10 +743,6 @@ class Miriad(UVData):
         if self.timesys is not None:
             uv.add_var('timesys', 'a')
             uv['timesys'] = self.timesys
-
-        if self.antenna_diameters is not None:
-            uv.add_var('antdiam', 'd')
-            uv['antdiam'] = self.antenna_diameters
 
         # other extra keywords
         # set up dictionaries to map common python types to miriad types


### PR DESCRIPTION
According to @pkgw's MIRIAD documentation (https://github.com/pkgw/viskit/blob/master/doc/uvvars.txt#L18-L19), the MIRIAD keyword for antenna diameters is `antdiam`. However, `pyuvdata` was instead looking for `diameter`. This PR now searches for the proper keyword, but is backwards compatible with the previous naming convention.