### PR TITLE
Add `ischan` and `nschan` to Miriad files

### DIFF
--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -58,14 +58,14 @@ class Miriad(UVData):
                                     'timesys', 'xorient', 'cnt', 'ra', 'dec',
                                     'lst', 'pol', 'nants', 'antnames', 'nblts',
                                     'ntimes', 'nbls', 'sfreq', 'epoch',
-                                    'antpos', 'antnums', 'degpdy', 'antdiam'
+                                    'antpos', 'antnums', 'degpdy', 'antdiam',
+                                    'ischan', 'nschan',
                                     ]
         # list of miriad variables not read, but also not interesting
         # NB: nspect (I think) is number of spectral windows, will want one day
-        other_miriad_variables = ['nspect', 'obsdec', 'vsource', 'ischan',
-                                  'restfreq', 'nschan', 'corr', 'freq',
-                                  'tscale', 'coord', 'veldop', 'time', 'obsra',
-                                  'operator', 'version',
+        other_miriad_variables = ['nspect', 'obsdec', 'vsource', 'restfreq',
+                                  'corr', 'freq', 'tscale', 'coord', 'veldop',
+                                  'time', 'obsra', 'operator', 'version',
                                   ]
 
         extra_miriad_variables = []

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -170,6 +170,10 @@ class Miriad(UVData):
             self.timesys = uv['timesys'].replace('\x00', '')
         if 'xorient' in uv.vartable.keys():
             self.x_orientation = uv['xorient'].replace('\x00', '')
+        if 'nschan' in uv.vartable.keys():
+            self.nschan = uv['nschan']
+        if 'ischan' in uv.vartable.keys():
+            self.ischan = uv['ischan']
 
         # read through the file and get the data
         _source = uv['source']  # check source of initial visibility
@@ -698,6 +702,12 @@ class Miriad(UVData):
             else:
                 uv.add_var('antdiam', 'd')
                 uv['antdiam'] = self.antenna_diameters[0]
+        if self.nschan is not None:
+            uv.add_var('nschan', 'i')
+            uv['nschan'] = self.nschan
+        if self.ischan is not None:
+            uv.add_var('ischan', 'i')
+            uv['ischan'] = self.ischan
 
         # Miriad has no way to keep track of antenna numbers, so the antenna
         # numbers are simply the index for each antenna in any array that

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -329,8 +329,19 @@ def test_readWriteReadMiriad():
     uv_out.read_miriad(write_file)
     nt.assert_equal(uv_in, uv_out)
 
+    # check that variables 'ischan' and 'nschan' were written to new file
+    # need to use aipy, since pyuvdata is not currently capturing these variables
+    uv_in.read_miriad(write_file)
+    uv_aipy = amiriad.UV(write_file)
+    nfreqs = uv_in.Nfreqs
+    nschan = uv_aipy['nschan']
+    ischan = uv_aipy['ischan']
+    nt.assert_equal(nschan, nfreqs)
+    nt.assert_equal(ischan, 1)
+
     del(uv_in)
     del(uv_out)
+    del(uv_aipy)
 
 
 def test_readMSWriteMiriad_CASAHistory():


### PR DESCRIPTION
This PR adds the Miriad variables `ischan` and `nschan` to Miriad output files, and addresses Issue #245. `ischan` is the starting channel of each spectral window, and `nschan` is the number of channels in each spectral window. Once pyuvdata supports more than one spectral window, these variables should be set using the `spw_array`. In the meantime, `ischan` is set to 1 (since channel number arrays in Miriad have 1-based indices) and `nschan` is set to the `Nfreqs` value of the `UVData` object.