### PR TITLE
Fix convert_to_gain function for files with total_quality_array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,8 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip
   - source activate test-environment
+  - conda uninstall libedit
   - conda install -c conda-forge aipy
-  - conda info libedit
-  - conda info python-casacore
   - conda install -c conda-forge python-casacore
   - pip install coveralls
 script: nosetests pyuvdata --with-coverage --cover-package=pyuvdata

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip
   - source activate test-environment
   - conda install -c conda-forge aipy
+  - conda info libedit
+  - conda info python-casacore
   - conda install -c conda-forge python-casacore
   - pip install coveralls
 script: nosetests pyuvdata --with-coverage --cover-package=pyuvdata

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip
-  - source activate test-environment
+  - conda install numpy scipy astropy nose pip
   - conda install -c conda-forge aipy
   - conda install -c conda-forge python-casacore
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-4.3.21-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
+  - conda install -y 'libgfortran =3.0.0'
+  - conda config --remove channels defaults && conda config --add channels conda-forge
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
@@ -26,7 +28,6 @@ install:
   # create environment and install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy nose pip
   - source activate test-environment
-  - conda uninstall libedit
   - conda install -c conda-forge aipy
   - conda install -c conda-forge python-casacore
   - pip install coveralls

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -189,6 +189,27 @@ class TestUVCalBasicMethods(object):
                                        rtol=self.new_object._quality_array.tols[0],
                                        atol=self.new_object._quality_array.tols[1]))
 
+        # test a file with a total_quality_array
+        self.new_object = copy.deepcopy(self.delay_object)
+        tqa_size = self.new_object.delay_array.shape[1:]
+        self.new_object.total_quality_array = np.ones(tqa_size)
+        self.new_object.convert_to_gain(delay_convention='minus')
+        nt.assert_true(np.isclose(np.max(np.absolute(self.new_object.gain_array)), 1.,
+                                  rtol=self.new_object._gain_array.tols[0],
+                                  atol=self.new_object._gain_array.tols[1]))
+        nt.assert_true(np.isclose(np.min(np.absolute(self.new_object.gain_array)), 1.,
+                                  rtol=self.new_object._gain_array.tols[0],
+                                  atol=self.new_object._gain_array.tols[1]))
+        nt.assert_true(np.allclose(np.angle(self.new_object.gain_array[:, :, 10, :, :]) % (2 * np.pi),
+                                   (-1 * 2 * np.pi * self.delay_object.delay_array[:, :, 0, :, :] *
+                                    self.delay_object.freq_array[0, 10]) % (2 * np.pi),
+                                   rtol=self.new_object._gain_array.tols[0],
+                                   atol=self.new_object._gain_array.tols[1]))
+        nt.assert_true(np.allclose(self.delay_object.quality_array,
+                                   self.new_object.quality_array[:, :, 10, :, :],
+                                   rtol=self.new_object._quality_array.tols[0],
+                                   atol=self.new_object._quality_array.tols[1]))
+
         # error testing
         nt.assert_raises(ValueError, self.delay_object.convert_to_gain, delay_convention='bogus')
         nt.assert_raises(ValueError, self.gain_object.convert_to_gain)

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -526,7 +526,7 @@ class UVCal(UVBase):
             self.quality_array = new_quality
             self.delay_array = None
             if self.total_quality_array is not None:
-                new_total_quality = np.repeat(self.total_quality_array[:, :, :, :], self.Nfreqs, axis=1)
+                new_total_quality_array = np.repeat(self.total_quality_array[:, :, :, :], self.Nfreqs, axis=1)
                 self.total_quality_array = new_total_quality_array
 
             # check if object is self-consistent

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -525,6 +525,9 @@ class UVCal(UVBase):
             self.gain_array = gain_array
             self.quality_array = new_quality
             self.delay_array = None
+            if self.total_quality_array is not None:
+                new_total_quality = np.repeat(self.total_quality_array[:, :, :, :], self.Nfreqs, axis=1)
+                self.total_quality_array = new_total_quality_array
 
             # check if object is self-consistent
             if run_check:


### PR DESCRIPTION
The function `convert_to_gain`, which takes a delay-type UVCal file and converts it to a gain-type file, was not also changing the size of the `total_quality_array` object. This addresses that issue, and adds a test.