### PR TITLE
antdiam dtype fix

### DIFF
--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -697,7 +697,7 @@ class Miriad(UVData):
                               'supports a single diameter. Skipping.')
             else:
                 uv.add_var('antdiam', 'd')
-                uv['antdiam'] = self.antenna_diameters[0]
+                uv['antdiam'] = float(self.antenna_diameters[0])
 
         # These are added to make files written by pyuvdata more "miriad correct", and
         # should be changed when support for more than one spectral window is added.

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -318,6 +318,12 @@ def test_readWriteReadMiriad():
     uv_out.read_miriad(write_file)
     nt.assert_equal(uv_in, uv_out)
 
+    # check that antenna diameters get written if not exactly float
+    uv_in.antenna_diameters = np.zeros((uv_in.Nants_telescope,), dtype=np.float32) + 14.0
+    uv_in.write_miriad(write_file, clobber=True)
+    uv_out.read_miriad(write_file)
+    nt.assert_equal(uv_in, uv_out)
+
     # check that trying to write a file with unknown phasing raises an error
     uv_in.set_unknown_phase_type()
     nt.assert_raises(ValueError, uv_in.write_miriad, write_file, clobber=True)


### PR DESCRIPTION
Super quick fix for case where antenna_diameters has non-miriad compatible dtype