### PR TITLE
Fix reordering in add function

### DIFF
--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -884,6 +884,15 @@ def test_add():
     uv1.select(blt_inds=ind1)
     uv2.select(blt_inds=ind2)
     uv3.select(blt_inds=ind3)
+    uv3.data_array = uv3.data_array[-1::-1, :, :, :]
+    uv3.nsample_array = uv3.nsample_array[-1::-1, :, :, :]
+    uv3.flag_array = uv3.flag_array[-1::-1, :, :, :]
+    uv3.uvw_array = uv3.uvw_array[-1::-1, :]
+    uv3.time_array = uv3.time_array[-1::-1]
+    uv3.lst_array = uv3.lst_array[-1::-1]
+    uv3.ant_1_array = uv3.ant_1_array[-1::-1]
+    uv3.ant_2_array = uv3.ant_2_array[-1::-1]
+    uv3.baseline_array = uv3.baseline_array[-1::-1]
     uv1 += uv3
     uv1 += uv2
     nt.assert_true(uvutils.check_histories(uv_full.history + '  Downselected to '

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -869,6 +869,32 @@ def test_add():
     uv1.history = uv_full.history
     nt.assert_equal(uv1, uv_full)
 
+    # Add baselines - out of order
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    uv3 = copy.deepcopy(uv_full)
+    ants = uv_full.get_ants()
+    ants1 = ants[0:6]
+    ants2 = ants[6:12]
+    ants3 = ants[12:]
+    # All blts where ant_1 is in list
+    ind1 = [i for i in range(uv1.Nblts) if uv1.ant_1_array[i] in ants1]
+    ind2 = [i for i in range(uv2.Nblts) if uv2.ant_1_array[i] in ants2]
+    ind3 = [i for i in range(uv3.Nblts) if uv3.ant_1_array[i] in ants3]
+    uv1.select(blt_inds=ind1)
+    uv2.select(blt_inds=ind2)
+    uv3.select(blt_inds=ind3)
+    uv1 += uv3
+    uv1 += uv2
+    nt.assert_true(uvutils.check_histories(uv_full.history + '  Downselected to '
+                                           'specific baseline-times using pyuvdata. '
+                                           'Combined data along baseline-time axis '
+                                           'using pyuvdata. Combined data along '
+                                           'baseline-time axis using pyuvdata.',
+                                           uv1.history))
+    uv1.history = uv_full.history
+    nt.assert_equal(uv1, uv_full)
+
     # Add multiple axes
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -828,59 +828,53 @@ class UVData(UVBase):
         # Pad out self to accommodate new data
         if len(bnew_inds) > 0:
             this_blts = np.concatenate((this_blts, new_blts))
-            order = np.argsort(this_blts)
-            this_blts = this_blts[order]
+            blt_order = np.argsort(this_blts)
+            this_blts = this_blts[blt_order]
             zero_pad = np.zeros(
                 (len(bnew_inds), this.Nspws, this.Nfreqs, this.Npols))
-            this.data_array = np.concatenate([this.data_array, zero_pad], axis=0)[
-                order, :, :, :]
-            this.nsample_array = np.concatenate(
-                [this.nsample_array, zero_pad], axis=0)[order, :, :, :]
+            this.data_array = np.concatenate([this.data_array, zero_pad], axis=0)
+            this.nsample_array = np.concatenate([this.nsample_array, zero_pad], axis=0)
             this.flag_array = np.concatenate([this.flag_array,
-                                              1 - zero_pad], axis=0).astype(np.bool)[order, :, :, :]
+                                              1 - zero_pad], axis=0).astype(np.bool)
             this.uvw_array = np.concatenate([this.uvw_array,
-                                             other.uvw_array[bnew_inds, :]], axis=0)[order, :]
+                                             other.uvw_array[bnew_inds, :]], axis=0)[blt_order, :]
             this.time_array = np.concatenate([this.time_array,
-                                              other.time_array[bnew_inds]])[order]
+                                              other.time_array[bnew_inds]])[blt_order]
             this.lst_array = np.concatenate(
-                [this.lst_array, other.lst_array[bnew_inds]])[order]
+                [this.lst_array, other.lst_array[bnew_inds]])[blt_order]
             this.ant_1_array = np.concatenate([this.ant_1_array,
-                                               other.ant_1_array[bnew_inds]])[order]
+                                               other.ant_1_array[bnew_inds]])[blt_order]
             this.ant_2_array = np.concatenate([this.ant_2_array,
-                                               other.ant_2_array[bnew_inds]])[order]
+                                               other.ant_2_array[bnew_inds]])[blt_order]
             this.baseline_array = np.concatenate([this.baseline_array,
-                                                  other.baseline_array[bnew_inds]])[order]
+                                                  other.baseline_array[bnew_inds]])[blt_order]
             if this.phase_type == 'drift':
                 this.zenith_ra = np.concatenate([this.zenith_ra,
-                                                 other.zenith_ra[bnew_inds]])[order]
+                                                 other.zenith_ra[bnew_inds]])[blt_order]
                 this.zenith_dec = np.concatenate([this.zenith_dec,
-                                                 other.zenith_dec[bnew_inds]])[order]
+                                                 other.zenith_dec[bnew_inds]])[blt_order]
         if len(fnew_inds) > 0:
             zero_pad = np.zeros((this.data_array.shape[0], this.Nspws, len(fnew_inds),
                                  this.Npols))
             this.freq_array = np.concatenate([this.freq_array,
                                               other.freq_array[:, fnew_inds]], axis=1)
-            order = np.argsort(this.freq_array[0, :])
-            this.freq_array = this.freq_array[:, order]
-            this.data_array = np.concatenate([this.data_array, zero_pad], axis=2)[
-                :, :, order, :]
-            this.nsample_array = np.concatenate(
-                [this.nsample_array, zero_pad], axis=2)[:, :, order, :]
+            f_order = np.argsort(this.freq_array[0, :])
+            this.freq_array = this.freq_array[:, f_order]
+            this.data_array = np.concatenate([this.data_array, zero_pad], axis=2)
+            this.nsample_array = np.concatenate([this.nsample_array, zero_pad], axis=2)
             this.flag_array = np.concatenate([this.flag_array, 1 - zero_pad],
-                                             axis=2).astype(np.bool)[:, :, order, :]
+                                             axis=2).astype(np.bool)
         if len(pnew_inds) > 0:
             zero_pad = np.zeros((this.data_array.shape[0], this.Nspws,
                                  this.data_array.shape[2], len(pnew_inds)))
             this.polarization_array = np.concatenate([this.polarization_array,
                                                       other.polarization_array[pnew_inds]])
-            order = np.argsort(np.abs(this.polarization_array))
-            this.polarization_array = this.polarization_array[order]
-            this.data_array = np.concatenate([this.data_array, zero_pad], axis=3)[
-                :, :, :, order]
-            this.nsample_array = np.concatenate(
-                [this.nsample_array, zero_pad], axis=3)[:, :, :, order]
+            p_order = np.argsort(np.abs(this.polarization_array))
+            this.polarization_array = this.polarization_array[p_order]
+            this.data_array = np.concatenate([this.data_array, zero_pad], axis=3)
+            this.nsample_array = np.concatenate([this.nsample_array, zero_pad], axis=3)
             this.flag_array = np.concatenate([this.flag_array, 1 - zero_pad],
-                                             axis=3).astype(np.bool)[:, :, :, order]
+                                             axis=3).astype(np.bool)
 
         # Now populate the data
         pol_t2o = np.nonzero(
@@ -894,6 +888,18 @@ class UVData(UVBase):
             blt_t2o, [0], freq_t2o, pol_t2o)] = other.nsample_array
         this.flag_array[np.ix_(blt_t2o, [0], freq_t2o,
                                pol_t2o)] = other.flag_array
+        if len(bnew_inds) > 0:
+            this.data_array = this.data_array[blt_order, :, :, :]
+            this.nsample_array = this.nsample_array[blt_order, :, :, :]
+            this.flag_array = this.flag_array[blt_order, :, :, :]
+        if len(fnew_inds) > 0:
+            this.data_array = this.data_array[:, :, f_order, :]
+            this.nsample_array = this.nsample_array[:, :, f_order, :]
+            this.flag_array = this.flag_array[:, :, f_order, :]
+        if len(pnew_inds) > 0:
+            this.data_array = this.data_array[:, :, :, p_order]
+            this.nsample_array = this.nsample_array[:, :, :, p_order]
+            this.flag_array = this.flag_array[:, :, :, p_order]
 
         # Update N parameters (e.g. Npols)
         this.Ntimes = len(np.unique(this.time_array))

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -829,7 +829,6 @@ class UVData(UVBase):
         if len(bnew_inds) > 0:
             this_blts = np.concatenate((this_blts, new_blts))
             blt_order = np.argsort(this_blts)
-            this_blts = this_blts[blt_order]
             zero_pad = np.zeros(
                 (len(bnew_inds), this.Nspws, this.Nfreqs, this.Npols))
             this.data_array = np.concatenate([this.data_array, zero_pad], axis=0)


### PR DESCRIPTION
If the data weren't already ordered by time, ant2, ant1, adding objects together resulted in a scramble. This addresses issue #254.