### PR TITLE
Fix warnings in parse_ants from test_uvdata.py and uvdata.py

### DIFF
--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1715,8 +1715,11 @@ def test_parse_ants():
 
     # Single antenna number not in the data
     ant_str = '10'
-    ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
-    nt.assert_items_equal(ant_pairs_nums, [])
+    ant_pairs_nums, polarizations = uvtest.checkWarnings(
+                                    uv.parse_ants, [ant_str], {},
+                                    nwarnings=1,
+                                    message='Warning: Antenna')
+    nt.assert_is_instance(ant_pairs_nums, type(None))
     nt.assert_is_instance(polarizations, type(None))
 
     # Multiple antenna numbers as list
@@ -1750,10 +1753,10 @@ def test_parse_ants():
 
     # Single baseline with single polarization in first entry
     ant_str = '1l_3,2x_3'
-    uvtest.checkWarnings(uv.parse_ants, [ant_str], {},
-                                    nwarnings=2, category=[UserWarning]*2,
-                                    message=['Warning: Polarization']*2)
-    ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
+    ant_pairs_nums, polarizations = uvtest.checkWarnings(
+                                    uv.parse_ants, [ant_str], {},
+                                    nwarnings=1,
+                                    message='Warning: Polarization')
     ant_pairs_expected = [(1, 3), (2, 3)]
     pols_expected = [-2, -4]
     nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
@@ -1761,10 +1764,10 @@ def test_parse_ants():
 
     # Single baseline with single polarization in last entry
     ant_str = '1_3l,2_3x'
-    uvtest.checkWarnings(uv.parse_ants, [ant_str], {},
-                                    nwarnings=2, category=[UserWarning]*2,
-                                    message=['Warning: Polarization']*2)
-    ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
+    ant_pairs_nums, polarizations = uvtest.checkWarnings(
+                                    uv.parse_ants, [ant_str], {},
+                                    nwarnings=1,
+                                    message='Warning: Polarization')
     ant_pairs_expected = [(1, 3), (2, 3)]
     pols_expected = [-2, -3]
     nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
@@ -1848,7 +1851,9 @@ def test_parse_ants():
     # Test ant_str='auto' on file with auto correlations
     uv = UVData()
     testfile = os.path.join(DATA_PATH, 'hera_testfile')
-    uv.read_miriad(testfile)
+    uvtest.checkWarnings(uv.read_miriad, [testfile],
+                                    nwarnings=1,
+                                    message='Altitude is not')
 
     ant_str = 'auto'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
@@ -1942,7 +1947,9 @@ def test_select_with_ant_str():
 
     # Single antenna number not present in data
     ant_str = '10'
-    nt.assert_raises(ValueError, uv.select, ant_str=ant_str, inplace=inplace)
+    uv2 = uvtest.checkWarnings(uv.select, [],
+                                    {'ant_str': ant_str, 'inplace': inplace},
+                                    nwarnings=1, message='Warning: Antenna')
 
     # Multiple antenna numbers as list
     ant_str = '22,26'
@@ -1975,9 +1982,9 @@ def test_select_with_ant_str():
     # Single baseline with single polarization in first entry
     ant_str = '1l_3,2x_3'
     # x,y pols not present in data
-    uvtest.checkWarnings(uv.select, [], {'ant_str': ant_str, 'inplace': inplace},
-                                    nwarnings=2, category=[UserWarning]*2,
-                                    message=['Warning: Polarization']*2)
+    uv2 = uvtest.checkWarnings(uv.select, [],
+                                    {'ant_str': ant_str, 'inplace': inplace},
+                                    nwarnings=1, message='Warning: Polarization')
     # with polarizations in data
     ant_str = '1l_3,2_3'
     ant_pairs = [(1, 3), (2, 3)]
@@ -1989,10 +1996,9 @@ def test_select_with_ant_str():
     # Single baseline with single polarization in last entry
     ant_str = '1_3l,2_3x'
     # x,y pols not present in data
-    uvtest.checkWarnings(uv.select, [], {'ant_str': ant_str, 'inplace': inplace},
-                                    nwarnings=2, category=[UserWarning]*2,
-                                    message=['Warning: Polarization']*2)
-    # nt.assert_raises(ValueError, uv.select, ant_str=ant_str, inplace=inplace)
+    uv2 = uvtest.checkWarnings(uv.select, [],
+                                    {'ant_str': ant_str, 'inplace': inplace},
+                                    nwarnings=1, message='Warning: Polarization')
     # with polarizations in data
     ant_str = '1_3l,2_3'
     ant_pairs = [(1, 3), (2, 3)]
@@ -2004,11 +2010,10 @@ def test_select_with_ant_str():
     # Multiple baselines as list
     ant_str = '1_2,1_3,1_10'
     # Antenna number 10 not in data
-    uvtest.checkWarnings(uv.select, [], {'ant_str': ant_str, 'inplace': inplace},
-                                    nwarnings=1, category=[UserWarning],
-                                    message=['Warning: Antenna'])
+    uv2 = uvtest.checkWarnings(uv.select, [],
+                                    {'ant_str': ant_str, 'inplace': inplace},
+                                    nwarnings=1, message='Warning: Antenna')
     ant_pairs = [(1, 2), (1, 3)]
-    uv2 = uv.select(ant_str=ant_str, inplace=inplace)
     nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
     nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
 
@@ -2092,7 +2097,9 @@ def test_select_with_ant_str():
     # Test ant_str = 'auto' on file with auto correlations
     uv = UVData()
     testfile = os.path.join(DATA_PATH, 'hera_testfile')
-    uv.read_miriad(testfile)
+    uvtest.checkWarnings(uv.read_miriad, [testfile],
+                                    nwarnings=1,
+                                    message='Altitude is not')
 
     ant_str = 'auto'
     ant_pairs = [(9, 9), (10, 10), (20, 20)]

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -12,7 +12,6 @@ import utils as uvutils
 import copy
 import collections
 import re
-import warnings
 
 
 class UVData(UVBase):
@@ -2026,26 +2025,14 @@ class UVData(UVBase):
                         else:
                             if not (ant_tuple[0] in ants_data or
                                 ant_tuple[0] in warned_ants):
-                                warnings.warn('Warning: '
-                                    'Antenna number {a} passed, but not present '
-                                    'in the ant_1_array or ant_2_array'.format(
-                                    a=ant_tuple[0]))
                                 warned_ants.append(ant_tuple[0])
                             if not (ant_tuple[1] in ants_data or
                                 ant_tuple[1] in warned_ants):
-                                warnings.warn('Warning: '
-                                    'Antenna number {a} passed, but not present '
-                                    'in the ant_1_array or ant_2_array'.format(
-                                    a=ant_tuple[1]))
                                 warned_ants.append(ant_tuple[1])
                             if not pols is None:
                                 for pol in pols:
                                     if not (pol.upper() in pols_data
                                         or pol in warned_pols):
-                                        warnings.warn('Warning: '
-                                            'Polarization {p} is not present in '
-                                            'the polarization_array'.format(
-                                            p=pol.upper()))
                                         warned_pols.append(pol)
                             continue
 
@@ -2059,10 +2046,6 @@ class UVData(UVBase):
                                         polarizations.append(uvutils.polstr2num(pol))
                                     elif not (pol.upper() in pols_data
                                         or pol in warned_pols):
-                                        warnings.warn('Warning: '
-                                            'Polarization {p} is not present in '
-                                            'the polarization_array'.format(
-                                            p=pol.upper()))
                                         warned_pols.append(pol)
                         else:
                             if not pols is None:
@@ -2075,10 +2058,6 @@ class UVData(UVBase):
                                             polarizations.remove(uvutils.polstr2num(pol))
                                     elif not (pol.upper() in pols_data
                                         or pol in warned_pols):
-                                        warnings.warn('Warning: '
-                                            'Polarization {p} is not present in '
-                                            'the polarization_array'.format(
-                                            p=pol.upper()))
                                         warned_pols.append(pol)
                             elif ant_tuple in ant_pairs_nums:
                                 ant_pairs_nums.remove(ant_tuple)
@@ -2086,10 +2065,7 @@ class UVData(UVBase):
         if ant_str.upper() == 'ALL':
             ant_pairs_nums = None
         elif len(ant_pairs_nums) == 0:
-            if (not ant_str.upper() in ['AUTO', 'CROSS']
-            and not ([True]*len(ant_str.split(',')) ==
-            [x.isdigit() for x in ant_str.split(',')])):
-                print ant_str + ' contains at least one non-digit that\'s not auto or cross'
+            if (not ant_str.upper() in ['AUTO', 'CROSS']):
                 ant_pairs_nums = None
 
         if len(polarizations) == 0:
@@ -2107,5 +2083,17 @@ class UVData(UVBase):
             if not polarizations is None:
                 for pol in polarizations:
                     print uvutils.polnum2str(pol)
+
+        if len(warned_ants) > 0:
+            warnings.warn('Warning: '
+                'Antenna number {a} passed, but not present '
+                'in the ant_1_array or ant_2_array'.format(
+                a=(',').join(map(str,warned_ants))))
+
+        if len(warned_pols) > 0:
+            warnings.warn('Warning: '
+                'Polarization {p} is not present in '
+                'the polarization_array'.format(
+                p=(',').join(warned_pols).upper()))
 
         return ant_pairs_nums, polarizations


### PR DESCRIPTION
Warnings from antennae and polarizations passed to parse_ants have been suppressed in test_uvdata.py.  Warnings are now generated at the end of parse_ants so that up to two warning messages are generated if an antenna number and/or polarization passed to parse_ants is not present in the object.