### PR TITLE
Add pep8 checking to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,7 @@ install:
 
   # create environment and install dependencies
   - conda install numpy scipy astropy nose pip
-  - conda install -c conda-forge healpy
-  - conda install -c conda-forge aipy
-  - conda install -c conda-forge python-casacore
-  - conda install -c conda-forge pycodestyle
-  - pip install coveralls
+  - conda install -c conda-forge healpy aipy python-casacore pycodestyle coveralls
   - conda list
 script:
   - nosetests pyuvdata --with-coverage --cover-package=pyuvdata

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
 script:
   - nosetests pyuvdata --with-coverage --cover-package=pyuvdata
   - python -m doctest docs/tutorial.rst
+  - pycodestyle */*.py
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 script:
   - nosetests pyuvdata --with-coverage --cover-package=pyuvdata
   - python -m doctest docs/tutorial.rst
-  - pycodestyle */*.py
+  - pycodestyle */*.py --ignore=E501
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - conda install -c conda-forge healpy
   - conda install -c conda-forge aipy
   - conda install -c conda-forge python-casacore
+  - conda install -c conda-forge pycodestyle
   - pip install coveralls
   - conda list
 script:


### PR DESCRIPTION
To prevent pep8 problems from being missed in PRs.

This ignores the line-length check (code E501).