### PR TITLE
Bugfix uvdata add

### DIFF
--- a/pyuvdata/tests/test_uvbeam.py
+++ b/pyuvdata/tests/test_uvbeam.py
@@ -788,6 +788,13 @@ def test_add():
     beam1.history = power_beam.history
     nt.assert_equal(beam1, power_beam)
 
+    # Out of order - axis1
+    beam1 = power_beam.select(axis1_inds=np.arange(180, 360), inplace=False)
+    beam2 = power_beam.select(axis1_inds=np.arange(0, 180), inplace=False)
+    beam1 += beam2
+    beam1.history = power_beam.history
+    nt.assert_equal(beam1, power_beam)
+
     # Add along second image axis
     beam1 = power_beam.select(axis2_inds=np.arange(0, 90), inplace=False)
     beam2 = power_beam.select(axis2_inds=np.arange(90, 181), inplace=False)
@@ -798,6 +805,13 @@ def test_add():
                                            'second image axis using pyuvdata. '
                                            'Combined data along second image axis '
                                            'using pyuvdata.', beam1.history))
+    beam1.history = power_beam.history
+    nt.assert_equal(beam1, power_beam)
+
+    # Out of order - axis2
+    beam1 = power_beam.select(axis2_inds=np.arange(90, 181), inplace=False)
+    beam2 = power_beam.select(axis2_inds=np.arange(0, 90), inplace=False)
+    beam1 += beam2
     beam1.history = power_beam.history
     nt.assert_equal(beam1, power_beam)
 
@@ -814,6 +828,13 @@ def test_add():
     beam1.history = power_beam.history
     nt.assert_equal(beam1, power_beam)
 
+    # Out of order - freqs
+    beam1 = power_beam.select(freq_chans=1, inplace=False)
+    beam2 = power_beam.select(freq_chans=0, inplace=False)
+    beam1 += beam2
+    beam1.history = power_beam.history
+    nt.assert_equal(beam1, power_beam)
+
     # Add polarizations
     beam1 = power_beam.select(polarizations=-5, inplace=False)
     beam2 = power_beam.select(polarizations=-6, inplace=False)
@@ -823,6 +844,13 @@ def test_add():
                                            'using pyuvdata. Combined data along '
                                            'polarization axis using pyuvdata.',
                                            beam1.history))
+    beam1.history = power_beam.history
+    nt.assert_equal(beam1, power_beam)
+
+    # Out of order - pols
+    beam1 = power_beam.select(polarizations=-6, inplace=False)
+    beam2 = power_beam.select(polarizations=-5, inplace=False)
+    beam1 += beam2
     beam1.history = power_beam.history
     nt.assert_equal(beam1, power_beam)
 
@@ -855,6 +883,13 @@ def test_add():
                                            'using pyuvdata. Combined data along '
                                            'feed axis using pyuvdata.',
                                            beam1.history))
+    beam1.history = efield_beam.history
+    nt.assert_equal(beam1, efield_beam)
+
+    # Out of order - feeds
+    beam1 = efield_beam.select(feeds=efield_beam.feed_array[1], inplace=False)
+    beam2 = efield_beam.select(feeds=efield_beam.feed_array[0], inplace=False)
+    beam1 += beam2
     beam1.history = efield_beam.history
     nt.assert_equal(beam1, efield_beam)
 

--- a/pyuvdata/tests/test_uvcal.py
+++ b/pyuvdata/tests/test_uvcal.py
@@ -876,6 +876,15 @@ class TestUVCalAddGain(object):
                                    rtol=self.gain_object._total_quality_array.tols[0],
                                    atol=self.gain_object._total_quality_array.tols[1]))
 
+        # Out of order - freqs
+        self.gain_object = copy.deepcopy(gain_object_full)
+        self.gain_object2 = copy.deepcopy(gain_object_full)
+        self.gain_object.select(frequencies=freqs2)
+        self.gain_object2.select(frequencies=freqs1)
+        self.gain_object += self.gain_object2
+        self.gain_object.history = gain_object_full.history
+        nt.assert_equal(self.gain_object, gain_object_full)
+
     def test_add_times(self):
         """Test adding times between two UVCal objects"""
         gain_object_full = copy.deepcopy(self.gain_object)
@@ -1214,6 +1223,15 @@ class TestUVCalAddDelay(object):
         self.delay_object += self.delay_object2
         nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
 
+        # Out of order - antennas
+        self.delay_object = copy.deepcopy(delay_object_full)
+        self.delay_object2 = copy.deepcopy(self.delay_object)
+        self.delay_object.select(antenna_nums=ants2)
+        self.delay_object2.select(antenna_nums=ants1)
+        self.delay_object += self.delay_object2
+        self.delay_object.history = delay_object_full.history
+        nt.assert_equal(self.delay_object, delay_object_full)
+
     def test_add_times(self):
         """Test adding times between two UVCal objects"""
         delay_object_full = copy.deepcopy(self.delay_object)
@@ -1298,6 +1316,15 @@ class TestUVCalAddDelay(object):
         self.delay_object += self.delay_object2
         nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
 
+        # Out of order - times
+        self.delay_object = copy.deepcopy(delay_object_full)
+        self.delay_object2 = copy.deepcopy(self.delay_object)
+        self.delay_object.select(times=times2)
+        self.delay_object2.select(times=times1)
+        self.delay_object += self.delay_object2
+        self.delay_object.history = delay_object_full.history
+        nt.assert_equal(self.delay_object, delay_object_full)
+
     def test_add_jones(self):
         """Test adding Jones axes between two UVCal objects"""
         delay_object_original = copy.deepcopy(self.delay_object)
@@ -1373,6 +1400,20 @@ class TestUVCalAddDelay(object):
         self.delay_object2.input_flag_array = ifa2
         self.delay_object += self.delay_object2
         nt.assert_true(np.allclose(self.delay_object.input_flag_array, tot_ifa))
+
+        # Out of order - jones
+        self.delay_object = copy.deepcopy(delay_object_original)
+        self.delay_object2 = copy.deepcopy(delay_object_original)
+        self.delay_object.jones_array[0] = -6
+        self.delay_object += self.delay_object2
+        self.delay_object2 = copy.deepcopy(self.delay_object)
+        self.delay_object.select(jones=-5)
+        self.delay_object.history = delay_object_original.history
+        nt.assert_equal(self.delay_object, delay_object_original)
+        self.delay_object2.select(jones=-6)
+        self.delay_object2.jones_array[:] = -5
+        self.delay_object2.history = delay_object_original.history
+        nt.assert_equal(self.delay_object2, delay_object_original)
 
     def test_add_errors(self):
         """Test behavior that will raise errors"""

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -835,6 +835,15 @@ def test_add():
     uv1.history = uv_full.history
     nt.assert_equal(uv1, uv_full)
 
+    # Add frequencies - out of order
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    uv1.select(freq_chans=np.arange(0, 32))
+    uv2.select(freq_chans=np.arange(32, 64))
+    uv2 += uv1
+    uv2.history = uv_full.history
+    nt.assert_equal(uv2, uv_full)
+
     # Add polarizations
     uv1 = copy.deepcopy(uv_full)
     uv2 = copy.deepcopy(uv_full)
@@ -847,6 +856,15 @@ def test_add():
                                            'using pyuvdata.', uv1.history))
     uv1.history = uv_full.history
     nt.assert_equal(uv1, uv_full)
+
+    # Add polarizations - out of order
+    uv1 = copy.deepcopy(uv_full)
+    uv2 = copy.deepcopy(uv_full)
+    uv1.select(polarizations=uv1.polarization_array[0:2])
+    uv2.select(polarizations=uv2.polarization_array[2:4])
+    uv2 += uv1
+    uv2.history = uv_full.history
+    nt.assert_equal(uv2, uv_full)
 
     # Add times
     uv1 = copy.deepcopy(uv_full)

--- a/pyuvdata/uvcal.py
+++ b/pyuvdata/uvcal.py
@@ -1055,6 +1055,7 @@ class UVCal(UVBase):
                  this.flag_array.shape[3], len(jnew_inds)))
             this.jones_array = np.concatenate([this.jones_array, other.jones_array[jnew_inds]])
             order = np.argsort(np.abs(this.jones_array))
+            this.jones_array = this.jones_array[order]
             if this.cal_type == 'delay':
                 this.delay_array = np.concatenate([this.delay_array, zero_pad_data], axis=4)[
                     :, :, :, :, order]

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -861,7 +861,6 @@ class UVData(UVBase):
             this.freq_array = np.concatenate([this.freq_array,
                                               other.freq_array[:, fnew_inds]], axis=1)
             f_order = np.argsort(this.freq_array[0, :])
-            this.freq_array = this.freq_array[:, f_order]
             this.data_array = np.concatenate([this.data_array, zero_pad], axis=2)
             this.nsample_array = np.concatenate([this.nsample_array, zero_pad], axis=2)
             this.flag_array = np.concatenate([this.flag_array, 1 - zero_pad],
@@ -872,7 +871,6 @@ class UVData(UVBase):
             this.polarization_array = np.concatenate([this.polarization_array,
                                                       other.polarization_array[pnew_inds]])
             p_order = np.argsort(np.abs(this.polarization_array))
-            this.polarization_array = this.polarization_array[p_order]
             this.data_array = np.concatenate([this.data_array, zero_pad], axis=3)
             this.nsample_array = np.concatenate([this.nsample_array, zero_pad], axis=3)
             this.flag_array = np.concatenate([this.flag_array, 1 - zero_pad],
@@ -895,10 +893,12 @@ class UVData(UVBase):
             this.nsample_array = this.nsample_array[blt_order, :, :, :]
             this.flag_array = this.flag_array[blt_order, :, :, :]
         if len(fnew_inds) > 0:
+            this.freq_array = this.freq_array[:, f_order]
             this.data_array = this.data_array[:, :, f_order, :]
             this.nsample_array = this.nsample_array[:, :, f_order, :]
             this.flag_array = this.flag_array[:, :, f_order, :]
         if len(pnew_inds) > 0:
+            this.polarization_array = this.polarization_array[p_order]
             this.data_array = this.data_array[:, :, :, p_order]
             this.nsample_array = this.nsample_array[:, :, :, p_order]
             this.flag_array = this.flag_array[:, :, :, p_order]


### PR DESCRIPTION
This addresses Issue #299 . It turns out there was a serious bug where data was getting overwritten in the add functions if the axes were out of canonical order. I've added tests and fixed the problem in UVData and a single case in UVCal. It turns out UVBeam was safe and several cases in UVCal were also safe.
It would be good to have multiple eyes on this because it was a pretty serious bug on a fairly core feature. I'm hoping @jsdillon can check it against his data he was working on, and @bhazelton could look over the code to make sure it's reasonable.