### PR TITLE
Fixes to write_calfits to ensure units are correct and tols are met

### DIFF
--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -76,13 +76,15 @@ class CALFITS(UVCal):
                 raise ValueError('The times are not evenly spaced (probably '
                                  'because of a select operation). The calfits format '
                                  'does not support unevenly spaced times.')
-            if np.isclose(time_spacing[0], self.integration_time):
-                time_spacing = self.integration_time
+            if np.isclose(time_spacing[0], self.integration_time / (24. * 60.**2)):
+                time_spacing = self.integration_time / (24. * 60.**2)
             else:
-                rounded_spacing = np.around(time_spacing, int(np.ceil(np.log10(self._time_array.tols[1]) * -1)))
+                rounded_spacing = np.around(time_spacing,
+                                            int(np.ceil(np.log10(self._time_array.tols[1] /
+                                                                 self.Ntimes) * -1) + 1))
                 time_spacing = rounded_spacing[0]
         else:
-            time_spacing = self.integration_time
+            time_spacing = self.integration_time / (24. * 60.**2)
 
         if self.Njones > 1:
             jones_spacing = np.diff(self.jones_array)

--- a/pyuvdata/tests/test_calfits.py
+++ b/pyuvdata/tests/test_calfits.py
@@ -523,3 +523,21 @@ def test_total_quality_array_size():
     proper_shape = (cal_in.Nspws, 1, cal_in.Ntimes, cal_in.Njones)
     nt.assert_equal(cal_in.total_quality_array.shape, proper_shape)
     del(cal_in)
+
+
+def test_write_time_precision():
+    """
+    Test that times are being written to appropriate precision (see issue 311).
+    """
+    cal_in = UVCal()
+    cal_out = UVCal()
+    testfile = os.path.join(DATA_PATH, 'zen.2457698.40355.xx.fitsA')
+    write_file = os.path.join(DATA_PATH, 'test/outtest_omnical.fits')
+    message = testfile + ' appears to be an old calfits format which'
+    uvtest.checkWarnings(cal_in.read_calfits, [testfile], message=message)
+    # overwrite time array to break old code
+    dt = cal_in.integration_time / (24. * 60. * 60.)
+    cal_in.time_array = dt * np.arange(cal_in.Ntimes)
+    cal_in.write_calfits(write_file, clobber=True)
+    cal_out.read_calfits(write_file)
+    nt.assert_equal(cal_in, cal_out)


### PR DESCRIPTION
Addresses #311.
I worry that this will affect downstream pipelines, because it looks like there were certain scenarios where the time deltas were being stored in units of seconds, and other instances stored in units of days. So it would be good to have @zakiali @jsdillon and @nkern look at this to see if we need to include backwards compatibility.