### PR TITLE
Add a check for unflagged data with nsample=0 in write_uvfits

### DIFF
--- a/pyuvdata/tests/test_uvfits.py
+++ b/pyuvdata/tests/test_uvfits.py
@@ -84,10 +84,14 @@ def test_readwriteread():
     nt.assert_equal(uv_in, uv_out)
 
     # check error if timesys is 'IAT'
-    testfile = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
-    uvtest.checkWarnings(uv_in.read_uvfits, [testfile], message='Telescope EVLA is not')
     uv_in.timesys = 'IAT'
     nt.assert_raises(ValueError, uv_in.write_uvfits, write_file)
+    uv_in.timesys = 'UTC'
+
+    # check that unflagged data with nsample = 0 will cause warnings
+    uv_in.nsample_array[range(11, 22)] = 0
+    uv_in.flag_array[range(11, 22)] = False
+    uvtest.checkWarnings(uv_in.write_uvfits, [write_file], message='Some unflagged data has nsample = 0')
 
     del(uv_in)
     del(uv_out)

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -385,6 +385,13 @@ class UVFITS(UVData):
                                          'spoof this attribute.'
                                          .format(attribute=p))
 
+        # check for unflagged data with nsample = 0. Warn if any found
+        wh_nsample0 = np.where(self.nsample_array == 0)[0]
+        if np.any(~self.flag_array[wh_nsample0]):
+            warnings.warn('Some unflagged data has nsample = 0. Flags and '
+                          'nsamples are combined in uvfits files such that '
+                          'these data will appear to be flagged.')
+
         weights_array = self.nsample_array * \
             np.where(self.flag_array, -1, 1)
         data_array = self.data_array[:, np.newaxis,


### PR DESCRIPTION
Issue warning in write_uvfits for unflagged data with nsample=0 because uvfits files combines flags & nsamples in such a way that nsample=0 data are effectively always flagged.

fixes issue #307