### PR TITLE
allowed vis_units to additionally be mK str

### DIFF
--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -55,10 +55,10 @@ class UVData(UVBase):
                                                  'Nfreqs', 'Npols'),
                                            expected_type=np.complex)
 
-        desc = 'Visibility units, options are: "uncalib", "Jy" or "K str"'
+        desc = 'Visibility units, options are: "uncalib", "Jy" or "K str", "mK str"'
         self._vis_units = uvp.UVParameter('vis_units', description=desc,
                                           form='str', expected_type=str,
-                                          acceptable_vals=["uncalib", "Jy", "K str"])
+                                          acceptable_vals=["uncalib", "Jy", "K str", "mK str"])
 
         desc = ('Number of data points averaged into each data element, '
                 'NOT required to be an integer. type = float, same shape as data_array')

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -55,10 +55,11 @@ class UVData(UVBase):
                                                  'Nfreqs', 'Npols'),
                                            expected_type=np.complex)
 
-        desc = 'Visibility units, options are: "uncalib", "Jy" or "K str", "mK str"'
+        desc = 'Visibility units, options are: "uncalib", "Jy" or "K str", "mK str", "mK", "K"'
         self._vis_units = uvp.UVParameter('vis_units', description=desc,
                                           form='str', expected_type=str,
-                                          acceptable_vals=["uncalib", "Jy", "K str", "mK str"])
+                                          acceptable_vals=["uncalib", "Jy", "K str", "mK str",
+                                                           "mK", "K"])
 
         desc = ('Number of data points averaged into each data element, '
                 'NOT required to be an integer. type = float, same shape as data_array')


### PR DESCRIPTION
it would be nice to allow the `units` of a UVData object to additionally be`mK str`, `mK` or `K`. Specifically, the input to `hera_pspec` will be visibility data in units of `mK` (where we have already divided out by the beam integral to get rid of the `str` units).