### PR TITLE
added data selection for uvdata.read_miriad and miriad.read_miriad

### DIFF
--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -52,7 +52,8 @@ class Miriad(UVData):
                 numbers within the tuple does not matter. A single antenna iterable
                 e.g. (1,) is interpreted as all visibilities with that antenna.
             ant_str: A string containing information about what kinds of visibility data
-                to read-in.  Can be 'auto', 'cross', 'all'.
+                to read-in.  Can be 'auto', 'cross', 'all'. Cannot provide ant_str if
+                antenna_nums and/or ant_pairs_nums is not None.
             polarizations: List of polarization integers or strings to read-in.
                 Ex: ['xx', 'yy', ...]
             time_range: len-2 list containing min and max range of times (Julian Date) to read-in.
@@ -204,6 +205,7 @@ class Miriad(UVData):
         if ant_str is not None:
             # type check
             assert isinstance(ant_str, (str, np.str)), "ant_str must be fed as a string"
+            assert antenna_nums is None and ant_pairs_nums is None, "ant_str must be None if antenna_nums or ant_pairs_nums is not None"
             aipy.scripting.uv_selector(uv, ant_str)
         # select on antenna_nums and/or ant_pairs_nums using aipy.scripting.uv_selector
         if antenna_nums is not None or ant_pairs_nums is not None:

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -48,7 +48,7 @@ class Miriad(UVData):
             antpairs: List of antnum-pair tuples in data to read-in.
                 If a tuple contains a single antnum, read-in all baselines that touch that antnum.
                 In this case, make sure the tuple is an iterable, e.g. (2,) not (2).
-                Ex: [(0, 0), (0, 1), (2,), ...]. 
+                Ex: [(0, 0), (0, 1), (2,), ...].
             pols: List of polarization integers or strings to only read-in.
                 Ex: ['xx', 'yy', ...]
             times: len-2 list containing min and max range of times (Julian Date) to read-in.
@@ -196,14 +196,14 @@ class Miriad(UVData):
         for extra_variable in extra_miriad_variables:
             check_variables[extra_variable] = uv[extra_variable]
 
-        ## perform data selections if provided ##
+        # perform data selections if provided
         # select on antpairs using aipy.scripting.uv_selector
         if antpairs is not None:
             # type check
             err_msg = "antpairs must be a list of antnum integer tuples, Ex: [(0, 1), (3,), ...]"
             assert isinstance(antpairs, list), err_msg
             assert np.array(map(lambda ap: isinstance(ap, tuple), antpairs)).all(), err_msg
-            assert np.array(map(lambda ap: map(lambda a: isinstance(a, (int,np.int,np.int32)), ap), antpairs)).all(), err_msg
+            assert np.array(map(lambda ap: map(lambda a: isinstance(a, (int, np.int, np.int32)), ap), antpairs)).all(), err_msg
             # convert ant-pair tuples to string form required by aipy.scripting.uv_selector
             antpair_str = ','.join(map(lambda ap: '_'.join(map(lambda a: str(a), ap)), antpairs))
             aipy.scripting.uv_selector(uv, antpair_str)
@@ -213,9 +213,9 @@ class Miriad(UVData):
             # type check
             err_msg = "pols must be a list of polarization strings or ints, Ex: ['xx', ...] or [-5, ...]"
             assert isinstance(pols, list), err_msg
-            assert np.array(map(lambda p: isinstance(p, (str,np.str,int,np.int,np.int32)), pols)).all(), err_msg
+            assert np.array(map(lambda p: isinstance(p, (str, np.str, int, np.int, np.int32)), pols)).all(), err_msg
             # convert to pol integer if string
-            pols = [p if isinstance(p, (int,np.int,np.int32)) else uvutils.polstr2num(p) for p in pols]
+            pols = [p if isinstance(p, (int, np.int, np.int32)) else uvutils.polstr2num(p) for p in pols]
             # iterate through all possible pols and reject if not in pols
             pol_list = []
             for p in np.arange(-8, 5):

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -204,7 +204,7 @@ class Miriad(UVData):
         if ant_str is not None:
             # typc check
             assert isinstance(ant_str, (str, np.str)), "ant_str must be fed as a string"
-            uv.select(ant_str, 0, 0)
+            aipy.scripting.uv_selector(uv, ant_str)
         # select on antenna_nums and/or ant_pairs_nums using aipy.scripting.uv_selector
         if antenna_nums is not None or ant_pairs_nums is not None:
             antpair_str = ''

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -31,7 +31,7 @@ class Miriad(UVData):
 
     def read_miriad(self, filepath, correct_lat_lon=True, run_check=True,
                     check_extra=True, run_check_acceptability=True, phase_type=None,
-                    antenna_nums=None, ant_str=None, ant_pairs_nums=None, 
+                    antenna_nums=None, ant_str=None, ant_pairs_nums=None,
                     polarizations=None, time_range=None):
         """
         Read in data from a miriad file.

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -202,7 +202,7 @@ class Miriad(UVData):
 
         # select on ant_str if provided
         if ant_str is not None:
-            # typc check
+            # type check
             assert isinstance(ant_str, (str, np.str)), "ant_str must be fed as a string"
             aipy.scripting.uv_selector(uv, ant_str)
         # select on antenna_nums and/or ant_pairs_nums using aipy.scripting.uv_selector

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -572,7 +572,7 @@ def test_readWriteReadMiriad():
     uv_in.read_miriad(testfile, antenna_nums=[0])
     diff = set(full.get_antpairs()) - set(uv_in.get_antpairs())
     nt.assert_true(0 not in np.unique(diff))
-    uv_in.read_miriad(testfile, antenna_nums=[0], ant_pairs_nums=[(2,4)])
+    uv_in.read_miriad(testfile, antenna_nums=[0], ant_pairs_nums=[(2, 4)])
     nt.assert_true(np.array([bl in uv_in.get_antpairs() for bl in [(0, 0), (2, 4)]]).all())
 
     # test time loading
@@ -631,7 +631,7 @@ def test_readWriteReadMiriad():
     # assert partial-read and select are same
     full.read_miriad(testfile)
     t = np.unique(full.time_array)
-    full.select(times=t[((t>2456865.607)&(t<2456865.609))])
+    full.select(times=t[((t > 2456865.607) & (t < 2456865.609))])
     full.history = ''
     uv_in.read_miriad(testfile, time_range=[2456865.607, 2456865.609])
     uv_in.history = ''

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -595,7 +595,7 @@ def test_readWriteReadMiriad():
     uv_in.history = ''
     full.history = ''
     nt.assert_equal(uv_in, full)
-
+    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, ant_str='auto', antenna_nums=[0,1])
 
     # assert exceptions
     nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, ant_pairs_nums='foo')

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -476,7 +476,7 @@ def test_breakReadMiriad():
     testfile = os.path.join(DATA_PATH, 'test/outtest_miriad.uv')
     uvtest.checkWarnings(uv_in.read_miriad, [miriad_file],
                          known_warning='miriad')
-    
+
     uvtest.checkWarnings(uv_in.read_miriad, [miriad_file],
                          known_warning='miriad')
     uv_in.Nblts += 10
@@ -559,7 +559,7 @@ def test_readWriteReadMiriad():
     nt.assert_equal(nschan, nfreqs)
     nt.assert_equal(ischan, 1)
 
-    ## check partial IO selections ##
+    # check partial IO selections
     full = UVData()
     full.read_miriad(testfile)
     uv_in = UVData()
@@ -575,7 +575,7 @@ def test_readWriteReadMiriad():
 
     # test time loading
     uv_in.read_miriad(testfile, times=[2456865.607, 2456865.609])
-    full_times = np.unique(full.time_array[(full.time_array>2456865.607)&(full.time_array<2456865.609)])
+    full_times = np.unique(full.time_array[(full.time_array > 2456865.607) & (full.time_array < 2456865.609)])
     nt.assert_true(np.isclose(np.unique(uv_in.time_array), full_times).all())
 
     # test polarization loading
@@ -586,16 +586,16 @@ def test_readWriteReadMiriad():
 
     # assert exceptions
     nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, antpairs='foo')
-    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, antpairs=[[0,1]])
-    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, antpairs=[('foo',)])
+    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, antpairs=[[0, 1]])
+    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, antpairs=[('foo', )])
     nt.assert_raises(ValueError, uv_in.read_miriad, testfile, antpairs=[(0, 10)])
     nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, pols='xx')
     nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, pols=[1.0])
     nt.assert_raises(ValueError, uv_in.read_miriad, testfile, pols=['yy'])
     nt.assert_raises(ValueError, uv_in.read_miriad, testfile, pols=['yy'])
     nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, times='foo')
-    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, times=[1,2,3])
-    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, times=['foo','bar'])
+    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, times=[1, 2, 3])
+    nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, times=['foo', 'bar'])
     nt.assert_raises(ValueError, uv_in.read_miriad, testfile, times=[10.1, 10.2])
 
     del(uv_in)

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -589,6 +589,13 @@ def test_readWriteReadMiriad():
     # test ant_str
     uv_in.read_miriad(testfile, ant_str='auto')
     nt.assert_true(np.array([blp[0] == blp[1] for blp in uv_in.get_antpairs()]).all())
+    uv_in.read_miriad(testfile, ant_str='cross')
+    nt.assert_true(np.array([blp[0] != blp[1] for blp in uv_in.get_antpairs()]).all())
+    uv_in.read_miriad(testfile, ant_str='all')
+    uv_in.history = ''
+    full.history = ''
+    nt.assert_equal(uv_in, full)
+
 
     # assert exceptions
     nt.assert_raises(AssertionError, uv_in.read_miriad, testfile, ant_pairs_nums='foo')

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1630,8 +1630,10 @@ class UVData(UVBase):
                 ones. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
-            antpairs: List of len-2 antnum integer tuples in data to only read-in.
-                Ex: [(0, 0), (0, 1), ...]
+            antpairs: List of antnum-pair tuples in data to read-in.
+                If a tuple contains a single antnum, read-in all baselines that touch that antnum.
+                In this case, make sure the tuple is an iterable, e.g. (2,) not (2).
+                Ex: [(0, 0), (0, 1), (2,), ...].
             pols: List of polarization integers or strings to only read-in.
                 Ex: ['xx', 'yy', ...]
             times: len-2 list containing min and max range of times (Julian Date) to read-in.

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1618,7 +1618,8 @@ class UVData(UVBase):
 
     def read_miriad(self, filepath, correct_lat_lon=True, run_check=True,
                     check_extra=True, run_check_acceptability=True, phase_type=None,
-                    antpairs=None, pols=None, times=None):
+                    antenna_nums=None, ant_str=None, ant_pairs_nums=None, 
+                    polarizations=None, time_range=None):
         """
         Read in data from a miriad file.
 
@@ -1630,13 +1631,16 @@ class UVData(UVBase):
                 ones. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
-            antpairs: List of antnum-pair tuples in data to read-in.
-                If a tuple contains a single antnum, read-in all baselines that touch that antnum.
-                In this case, make sure the tuple is an iterable, e.g. (2,) not (2).
-                Ex: [(0, 0), (0, 1), (2,), ...].
-            pols: List of polarization integers or strings to only read-in.
+            antenna_nums: The antennas numbers to read into the object.
+            ant_pairs_nums: A list of antenna number tuples (e.g. [(0,1), (3,2)])
+                specifying baselines to read into the object. Ordering of the
+                numbers within the tuple does not matter. A single antenna iterable
+                e.g. (1,) is interpreted as all visibilities with that antenna.
+            ant_str: A string containing information about what kinds of visibility data
+                to read-in.  Can be 'auto', 'cross', 'all'.
+            polarizations: List of polarization integers or strings to read-in.
                 Ex: ['xx', 'yy', ...]
-            times: len-2 list containing min and max range of times (Julian Date) to read-in.
+            time_range: len-2 list containing min and max range of times (Julian Date) to read-in.
                 Ex: [2458115.20, 2458115.40]
         """
         import miriad
@@ -1644,16 +1648,18 @@ class UVData(UVBase):
             self.read_miriad(filepath[0], correct_lat_lon=correct_lat_lon,
                              run_check=run_check, check_extra=check_extra,
                              run_check_acceptability=run_check_acceptability,
-                             phase_type=phase_type, antpairs=antpairs, pols=pols,
-                             times=times)
+                             phase_type=phase_type, antenna_nums=antenna_nums, 
+                             ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
+                             polarizations=polarizations, time_range=time_range)
             if len(filepath) > 1:
                 for f in filepath[1:]:
                     uv2 = UVData()
                     uv2.read_miriad(f, correct_lat_lon=correct_lat_lon,
                                     run_check=run_check, check_extra=check_extra,
                                     run_check_acceptability=run_check_acceptability,
-                                    phase_type=phase_type, antpairs=antpairs, pols=pols,
-                                    times=times)
+                                    phase_type=phase_type, antenna_nums=antenna_nums, 
+                                    ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
+                                    polarizations=polarizations, time_range=time_range)
                     self += uv2
                 del(uv2)
         else:
@@ -1661,8 +1667,9 @@ class UVData(UVBase):
             miriad_obj.read_miriad(filepath, correct_lat_lon=correct_lat_lon,
                                    run_check=run_check, check_extra=check_extra,
                                    run_check_acceptability=run_check_acceptability,
-                                   phase_type=phase_type, antpairs=antpairs, pols=pols,
-                                   times=times)
+                                   phase_type=phase_type, antenna_nums=antenna_nums, 
+                                   ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
+                                   polarizations=polarizations, time_range=time_range)
             self._convert_from_filetype(miriad_obj)
             del(miriad_obj)
 

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1637,7 +1637,8 @@ class UVData(UVBase):
                 numbers within the tuple does not matter. A single antenna iterable
                 e.g. (1,) is interpreted as all visibilities with that antenna.
             ant_str: A string containing information about what kinds of visibility data
-                to read-in.  Can be 'auto', 'cross', 'all'.
+                to read-in.  Can be 'auto', 'cross', 'all'. Cannot provide ant_str if
+                antenna_nums and/or ant_pairs_nums is not None.
             polarizations: List of polarization integers or strings to read-in.
                 Ex: ['xx', 'yy', ...]
             time_range: len-2 list containing min and max range of times (Julian Date) to read-in.

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1618,7 +1618,7 @@ class UVData(UVBase):
 
     def read_miriad(self, filepath, correct_lat_lon=True, run_check=True,
                     check_extra=True, run_check_acceptability=True, phase_type=None,
-                    antenna_nums=None, ant_str=None, ant_pairs_nums=None, 
+                    antenna_nums=None, ant_str=None, ant_pairs_nums=None,
                     polarizations=None, time_range=None):
         """
         Read in data from a miriad file.
@@ -1648,7 +1648,7 @@ class UVData(UVBase):
             self.read_miriad(filepath[0], correct_lat_lon=correct_lat_lon,
                              run_check=run_check, check_extra=check_extra,
                              run_check_acceptability=run_check_acceptability,
-                             phase_type=phase_type, antenna_nums=antenna_nums, 
+                             phase_type=phase_type, antenna_nums=antenna_nums,
                              ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
                              polarizations=polarizations, time_range=time_range)
             if len(filepath) > 1:
@@ -1657,7 +1657,7 @@ class UVData(UVBase):
                     uv2.read_miriad(f, correct_lat_lon=correct_lat_lon,
                                     run_check=run_check, check_extra=check_extra,
                                     run_check_acceptability=run_check_acceptability,
-                                    phase_type=phase_type, antenna_nums=antenna_nums, 
+                                    phase_type=phase_type, antenna_nums=antenna_nums,
                                     ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
                                     polarizations=polarizations, time_range=time_range)
                     self += uv2
@@ -1667,7 +1667,7 @@ class UVData(UVBase):
             miriad_obj.read_miriad(filepath, correct_lat_lon=correct_lat_lon,
                                    run_check=run_check, check_extra=check_extra,
                                    run_check_acceptability=run_check_acceptability,
-                                   phase_type=phase_type, antenna_nums=antenna_nums, 
+                                   phase_type=phase_type, antenna_nums=antenna_nums,
                                    ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
                                    polarizations=polarizations, time_range=time_range)
             self._convert_from_filetype(miriad_obj)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1617,8 +1617,8 @@ class UVData(UVBase):
             del(fhd_obj)
 
     def read_miriad(self, filepath, correct_lat_lon=True, run_check=True,
-                    check_extra=True,
-                    run_check_acceptability=True, phase_type=None):
+                    check_extra=True, run_check_acceptability=True, phase_type=None,
+                    antpairs=None, pols=None, times=None):
         """
         Read in data from a miriad file.
 
@@ -1630,20 +1630,28 @@ class UVData(UVBase):
                 ones. Default is True.
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
+            antpairs: List of len-2 antnum integer tuples in data to only read-in.
+                Ex: [(0, 0), (0, 1), ...]
+            pols: List of polarization integers or strings to only read-in.
+                Ex: ['xx', 'yy', ...]
+            times: len-2 list containing min and max range of times (Julian Date) to read-in.
+                Ex: [2458115.20, 2458115.40]
         """
         import miriad
         if isinstance(filepath, (list, tuple)):
             self.read_miriad(filepath[0], correct_lat_lon=correct_lat_lon,
                              run_check=run_check, check_extra=check_extra,
                              run_check_acceptability=run_check_acceptability,
-                             phase_type=phase_type)
+                             phase_type=phase_type, antpairs=antpairs, pols=pols,
+                             times=times)
             if len(filepath) > 1:
                 for f in filepath[1:]:
                     uv2 = UVData()
                     uv2.read_miriad(f, correct_lat_lon=correct_lat_lon,
                                     run_check=run_check, check_extra=check_extra,
                                     run_check_acceptability=run_check_acceptability,
-                                    phase_type=phase_type)
+                                    phase_type=phase_type, antpairs=antpairs, pols=pols,
+                                    times=times)
                     self += uv2
                 del(uv2)
         else:
@@ -1651,7 +1659,8 @@ class UVData(UVBase):
             miriad_obj.read_miriad(filepath, correct_lat_lon=correct_lat_lon,
                                    run_check=run_check, check_extra=check_extra,
                                    run_check_acceptability=run_check_acceptability,
-                                   phase_type=phase_type)
+                                   phase_type=phase_type, antpairs=antpairs, pols=pols,
+                                   times=times)
             self._convert_from_filetype(miriad_obj)
             del(miriad_obj)
 


### PR DESCRIPTION
Enables partial I/O for `UVData.read_miriad` and `miriad.read_miriad` methods.

For this to work on polarization I had to eliminate the following assertion in `miriad.read_miriad`
```
        if len(self.polarization_array) != self.Npols:
            warnings.warn('npols={npols} but found {n} pols in data file'.format(
                npols=self.Npols, n=len(self.polarization_array)))
```
which also necessitated removing a test in `test_miriad` to test for this warning. I'm not sure what use-case this is trying to account for, but if it is a vital catch then perhaps we can figure out how to put it back in.