### PR TITLE
Add phasing function calls to uvdata check function

### DIFF
--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -338,6 +338,14 @@ class UVData(UVBase):
             # Special case of only containing auto correlations, adjust uvw acceptable_range
             self._uvw_array.acceptable_range = (0.0, 0.0)
 
+        # set the phase type based on object's value
+        if self.phase_type == 'phased':
+            self.set_phased()
+        elif self.phase_type == 'drift':
+            self.set_drift()
+        else:
+            self.set_unknown_phase_type()
+
         super(UVData, self).check(check_extra=check_extra,
                                   run_check_acceptability=run_check_acceptability)
 


### PR DESCRIPTION
This PR adds a call to `set_phased()`, `set_drift()`, or `set_unknown_phase_type()` based on a UVData object's value of `phase_type` as part of the `check` function. This is useful for ensuring that all the relevant metadata is present when reading/writing a UVData object.