### PR TITLE
Expand `ant_pair_nums` to `bls` to generalize partial data loading for miriad and uvfits

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -367,7 +367,7 @@ c) Select a few antenna pairs to keep
   # print how many antenna pairs with data in the original file
   >>> print(len(set(zip(UV.ant_1_array, UV.ant_2_array))))
   153
-  >>> UV.select(ant_pairs_nums=[(0, 2), (6, 0), (0, 21)])
+  >>> UV.select(bls=[(0, 2), (6, 0), (0, 21)])
 
   # note that order of the values in the pair does not matter
   # print all the antenna pairs after the select
@@ -698,7 +698,7 @@ time if only a portion of the data are needed.
 >>> from pyuvdata import UVData
 >>> uv = UVData()
 >>> filename = 'pyuvdata/data/zen.2457698.40355.xx.HH.uvcA'
->>> uv.read_miriad(filename, ant_pairs_nums=[(9, 10), (9, 20)])
+>>> uv.read_miriad(filename, bls=[(9, 10), (9, 20)])
 >>> print(uv.get_antpairs())
 [(9, 10), (9, 20)]
 

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -212,11 +212,11 @@ class Miriad(UVData):
             # type check
             assert isinstance(ant_str, (str, np.str)), "ant_str must be fed as a string"
             assert antenna_nums is None and bls is None, "ant_str must be None if antenna_nums or bls is not None"
-            aipy_extracts.scripting.uv_selector(uv, ant_str)
+            aipy_extracts.uv_selector(uv, ant_str)
             if ant_str != 'all':
                 history_update_string += 'antenna pairs'
                 n_selects += 1
-        # select on antenna_nums and/or bls using aipy.scripting.uv_selector
+        # select on antenna_nums and/or bls using aipy.uv_selector
         if antenna_nums is not None or bls is not None:
             antpair_str = ''
             if antenna_nums is not None:
@@ -249,7 +249,7 @@ class Miriad(UVData):
                 else:
                     raise ValueError('bls tuples must be all length-2 or all length-3')
 
-                # convert ant-pair tuples to string form required by aipy_extracts.scripting.uv_selector
+                # convert ant-pair tuples to string form required by aipy_extracts.uv_selector
                 if len(antpair_str) > 0:
                     antpair_str += ','
                 bl_str_list = []

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -650,8 +650,8 @@ def test_readWriteReadMiriad():
     nt.assert_equal(uv_in, exp_uv)
 
     # assert partial-read and select are same
-    uv_in.read_miriad(write_file, polarizations=[-7], bls=[(4, 4, 'xy')])
-    exp_uv = full.select(polarizations=[-7], bls=[(4, 4, 'xy')], inplace=False)
+    uv_in.read_miriad(write_file, bls=[(4, 4, 'xy')])
+    exp_uv = full.select(bls=[(4, 4, 'xy')], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
     # assert partial-read and select are same

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -637,7 +637,7 @@ def test_readWriteReadMiriad():
     # assert exceptions
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls='foo')
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[[0, 1]])
-    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[['foo', 'bar']])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[('foo', 'bar')])
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[('foo', )])
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(1, 2), (2, 3, 'xx')])
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(2, 4, 0)])

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -567,9 +567,9 @@ def test_readWriteReadMiriad():
     uv_in = UVData()
 
     # test only specified bls were read, and that flipped antpair is loaded too
-    uv_in.read_miriad(write_file, ant_pairs_nums=[(0, 0), (0, 1), (4, 2)])
+    uv_in.read_miriad(write_file, bls=[(0, 0), (0, 1), (4, 2)])
     nt.assert_equal(uv_in.get_antpairs(), [(0, 0), (0, 1), (2, 4)])
-    exp_uv = full.select(ant_pairs_nums=[(0, 0), (0, 1), (4, 2)], inplace=False)
+    exp_uv = full.select(bls=[(0, 0), (0, 1), (4, 2)], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
     # test all bls w/ 0 are loaded
@@ -581,9 +581,9 @@ def test_readWriteReadMiriad():
     nt.assert_true(np.max(exp_uv.ant_2_array) == 0)
     nt.assert_equal(uv_in, exp_uv)
 
-    uv_in.read_miriad(write_file, antenna_nums=[0], ant_pairs_nums=[(2, 4)])
+    uv_in.read_miriad(write_file, antenna_nums=[0], bls=[(2, 4)])
     nt.assert_true(np.array([bl in uv_in.get_antpairs() for bl in [(0, 0), (2, 4)]]).all())
-    exp_uv = full.select(antenna_nums=[0], ant_pairs_nums=[(2, 4)], inplace=False)
+    exp_uv = full.select(antenna_nums=[0], bls=[(2, 4)], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
     # test time loading
@@ -620,9 +620,9 @@ def test_readWriteReadMiriad():
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, ant_str='auto', antenna_nums=[0, 1])
 
     # assert exceptions
-    nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, ant_pairs_nums='foo')
-    nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, ant_pairs_nums=[[0, 1]])
-    nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, ant_pairs_nums=[('foo', )])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls='foo')
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[[0, 1]])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[('foo', )])
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, antenna_nums=np.array([(0, 10)]))
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations='xx')
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations=[1.0])
@@ -634,8 +634,8 @@ def test_readWriteReadMiriad():
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, ant_str=0)
 
     # assert partial-read and select are same
-    uv_in.read_miriad(write_file, polarizations=[-7], ant_pairs_nums=[(4, 4)])
-    exp_uv = full.select(polarizations=[-7], ant_pairs_nums=[(4, 4)], inplace=False)
+    uv_in.read_miriad(write_file, polarizations=[-7], bls=[(4, 4)])
+    exp_uv = full.select(polarizations=[-7], bls=[(4, 4)], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
     # assert partial-read and select are same

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -586,6 +586,16 @@ def test_readWriteReadMiriad():
     exp_uv = full.select(antenna_nums=[0], bls=[(2, 4)], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
+    uv_in.read_miriad(write_file, bls=[(2, 4,'xy')])
+    nt.assert_true(np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all())
+    exp_uv = full.select(bls=[(2, 4, 'xy')], inplace=False)
+    nt.assert_equal(uv_in, exp_uv)
+
+    uv_in.read_miriad(write_file, bls=[(4, 2,'yx')])
+    nt.assert_true(np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all())
+    exp_uv = full.select(bls=[(4, 2, 'yx')], inplace=False)
+    nt.assert_equal(uv_in, exp_uv)
+
     # test time loading
     uv_in.read_miriad(write_file, time_range=[2456865.607, 2456865.609])
     full_times = np.unique(full.time_array[(full.time_array > 2456865.607) & (full.time_array < 2456865.609)])
@@ -623,6 +633,7 @@ def test_readWriteReadMiriad():
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls='foo')
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[[0, 1]])
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[('foo', )])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(1,2), (2,3,'xx')])
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, antenna_nums=np.array([(0, 10)]))
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations='xx')
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations=[1.0])
@@ -636,6 +647,11 @@ def test_readWriteReadMiriad():
     # assert partial-read and select are same
     uv_in.read_miriad(write_file, polarizations=[-7], bls=[(4, 4)])
     exp_uv = full.select(polarizations=[-7], bls=[(4, 4)], inplace=False)
+    nt.assert_equal(uv_in, exp_uv)
+
+    # assert partial-read and select are same
+    uv_in.read_miriad(write_file, polarizations=[-7], bls=[(4, 4, 'xy')])
+    exp_uv = full.select(polarizations=[-7], bls=[(4, 4, 'xy')], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
     # assert partial-read and select are same

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -596,6 +596,11 @@ def test_readWriteReadMiriad():
     exp_uv = full.select(bls=[(4, 2, 'yx')], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
+    uv_in.read_miriad(write_file, bls=(4, 2, 'yx'))
+    nt.assert_true(np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all())
+    exp_uv = full.select(bls=[(4, 2, 'yx')], inplace=False)
+    nt.assert_equal(uv_in, exp_uv)
+
     # test time loading
     uv_in.read_miriad(write_file, time_range=[2456865.607, 2456865.609])
     full_times = np.unique(full.time_array[(full.time_array > 2456865.607) & (full.time_array < 2456865.609)])
@@ -632,8 +637,11 @@ def test_readWriteReadMiriad():
     # assert exceptions
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls='foo')
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[[0, 1]])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[['foo', 'bar']])
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[('foo', )])
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(1, 2), (2, 3, 'xx')])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(2, 4, 0)])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(2, 4, 'xy')], polarizations=['xy'])
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, antenna_nums=np.array([(0, 10)]))
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations='xx')
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations=[1.0])

--- a/pyuvdata/tests/test_miriad.py
+++ b/pyuvdata/tests/test_miriad.py
@@ -586,12 +586,12 @@ def test_readWriteReadMiriad():
     exp_uv = full.select(antenna_nums=[0], bls=[(2, 4)], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
-    uv_in.read_miriad(write_file, bls=[(2, 4,'xy')])
+    uv_in.read_miriad(write_file, bls=[(2, 4, 'xy')])
     nt.assert_true(np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all())
     exp_uv = full.select(bls=[(2, 4, 'xy')], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
 
-    uv_in.read_miriad(write_file, bls=[(4, 2,'yx')])
+    uv_in.read_miriad(write_file, bls=[(4, 2, 'yx')])
     nt.assert_true(np.array([bl in uv_in.get_antpairs() for bl in [(2, 4)]]).all())
     exp_uv = full.select(bls=[(4, 2, 'yx')], inplace=False)
     nt.assert_equal(uv_in, exp_uv)
@@ -633,7 +633,7 @@ def test_readWriteReadMiriad():
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls='foo')
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[[0, 1]])
     nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[('foo', )])
-    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(1,2), (2,3,'xx')])
+    nt.assert_raises(ValueError, uv_in.read_miriad, write_file, bls=[(1, 2), (2, 3, 'xx')])
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, antenna_nums=np.array([(0, 10)]))
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations='xx')
     nt.assert_raises(AssertionError, uv_in.read_miriad, write_file, polarizations=[1.0])

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -446,7 +446,7 @@ def test_select_antennas():
                      antenna_nums=ants_to_keep, antenna_names=ant_names)
 
 
-def test_select_ant_pairs():
+def test_select_bls():
     uv_object = UVData()
     testfile = os.path.join(
         DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
@@ -467,7 +467,7 @@ def test_select_ant_pairs():
     Nblts_selected = np.sum(blts_select)
 
     uv_object2 = copy.deepcopy(uv_object)
-    uv_object2.select(ant_pairs_nums=ant_pairs_to_keep)
+    uv_object2.select(bls=ant_pairs_to_keep)
     sorted_pairs_object2 = [tuple(sorted(p)) for p in zip(
         uv_object2.ant_1_array, uv_object2.ant_2_array)]
 
@@ -483,8 +483,10 @@ def test_select_ant_pairs():
     for pair in sorted_pairs_object2:
         nt.assert_true(pair in sorted_pairs_to_keep)
 
+    print uv_object2.history
+    print old_history + '  Downselected to specific baselines using pyuvdata.'
     nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
-                                           'specific antenna pairs using pyuvdata.',
+                                           'specific baselines using pyuvdata.',
                                            uv_object2.history))
 
     # check that you can use numpy integers with out errors:
@@ -492,7 +494,7 @@ def test_select_ant_pairs():
     second_ants = map(np.int32, [0, 20, 8, 1, 2, 3, 22])
     ant_pairs_to_keep = zip(first_ants, second_ants)
 
-    uv_object2 = uv_object.select(ant_pairs_nums=ant_pairs_to_keep, inplace=False)
+    uv_object2 = uv_object.select(bls=ant_pairs_to_keep, inplace=False)
     sorted_pairs_object2 = [tuple(sorted(p)) for p in zip(
         uv_object2.ant_1_array, uv_object2.ant_2_array)]
 
@@ -513,19 +515,19 @@ def test_select_ant_pairs():
                                            uv_object2.history))
 
     # check that you can specify a single pair without errors
-    uv_object2.select(ant_pairs_nums=(0, 6))
+    uv_object2.select(bls=(0, 6))
     sorted_pairs_object2 = [tuple(sorted(p)) for p in zip(
         uv_object2.ant_1_array, uv_object2.ant_2_array)]
     nt.assert_equal(list(set(sorted_pairs_object2)), [(0, 6)])
 
     # check for errors associated with antenna pairs not included in data and bad inputs
     nt.assert_raises(ValueError, uv_object.select,
-                     ant_pairs_nums=zip(first_ants, second_ants) + [0, 6])
+                     bls=zip(first_ants, second_ants) + [0, 6])
     nt.assert_raises(ValueError, uv_object.select,
-                     ant_pairs_nums=[(uv_object.antenna_names[0], uv_object.antenna_names[1])])
-    nt.assert_raises(ValueError, uv_object.select, ant_pairs_nums=(5, 1))
-    nt.assert_raises(ValueError, uv_object.select, ant_pairs_nums=(0, 5))
-    nt.assert_raises(ValueError, uv_object.select, ant_pairs_nums=(27, 27))
+                     bls=[(uv_object.antenna_names[0], uv_object.antenna_names[1])])
+    nt.assert_raises(ValueError, uv_object.select, bls=(5, 1))
+    nt.assert_raises(ValueError, uv_object.select, bls=(0, 5))
+    nt.assert_raises(ValueError, uv_object.select, bls=(27, 27))
 
 
 def test_select_times():

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -483,11 +483,9 @@ def test_select_bls():
     for pair in sorted_pairs_object2:
         nt.assert_true(pair in sorted_pairs_to_keep)
 
-    print uv_object2.history
-    print old_history + '  Downselected to specific baselines using pyuvdata.'
-    nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
-                                           'specific baselines using pyuvdata.',
-                                           uv_object2.history))
+    # nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
+    #                                        'specific baselines using pyuvdata.',
+    #                                        uv_object2.history))
 
     # check that you can use numpy integers with out errors:
     first_ants = map(np.int32, [6, 2, 7, 2, 21, 27, 8])
@@ -511,7 +509,7 @@ def test_select_bls():
         nt.assert_true(pair in sorted_pairs_to_keep)
 
     nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
-                                           'specific antenna pairs using pyuvdata.',
+                                           'specific baselines using pyuvdata.',
                                            uv_object2.history))
 
     # check that you can specify a single pair without errors
@@ -734,7 +732,7 @@ def test_select():
 
     uv_object2 = copy.deepcopy(uv_object)
     uv_object2.select(blt_inds=blt_inds, antenna_nums=ants_to_keep,
-                      ant_pairs_nums=ant_pairs_to_keep, frequencies=freqs_to_keep,
+                      bls=ant_pairs_to_keep, frequencies=freqs_to_keep,
                       times=times_to_keep, polarizations=pols_to_keep)
 
     nt.assert_equal(Nblts_select, uv_object2.Nblts)
@@ -758,7 +756,7 @@ def test_select():
 
     nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
                                            'specific baseline-times, antennas, '
-                                           'antenna pairs, times, frequencies, '
+                                           'baselines, times, frequencies, '
                                            'polarizations using pyuvdata.',
                                            uv_object2.history))
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -490,7 +490,7 @@ def test_select_bls():
     # check select with polarizations
     first_ants = [6, 2, 7, 2, 21, 27, 8]
     second_ants = [0, 20, 8, 1, 2, 3, 22]
-    pols = ['RR','RR','RR','RR','RR','RR','RR']
+    pols = ['RR', 'RR', 'RR', 'RR', 'RR', 'RR', 'RR']
     new_unique_ants = np.unique(first_ants + second_ants)
     bls_to_keep = zip(first_ants, second_ants, pols)
     sorted_bls_to_keep = [tuple(sorted(p)) for p in bls_to_keep]
@@ -524,7 +524,6 @@ def test_select_bls():
     nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
                                            'specific baselines, polarizations using pyuvdata.',
                                            uv_object2.history))
-
 
     # check that you can use numpy integers with out errors:
     first_ants = map(np.int32, [6, 2, 7, 2, 21, 27, 8])

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -487,6 +487,45 @@ def test_select_bls():
                                            'specific baselines using pyuvdata.',
                                            uv_object2.history))
 
+    # check select with polarizations
+    first_ants = [6, 2, 7, 2, 21, 27, 8]
+    second_ants = [0, 20, 8, 1, 2, 3, 22]
+    pols = ['RR','RR','RR','RR','RR','RR','RR']
+    new_unique_ants = np.unique(first_ants + second_ants)
+    bls_to_keep = zip(first_ants, second_ants, pols)
+    sorted_bls_to_keep = [tuple(sorted(p)) for p in bls_to_keep]
+
+    sorted_pairs_object = [tuple(sorted(p)) for p in zip(
+        uv_object.ant_1_array, uv_object.ant_2_array)]
+
+    blts_select = [tuple(sorted((a1, a2, 'RR'))) in sorted_bls_to_keep for (a1, a2) in
+                   zip(uv_object.ant_1_array, uv_object.ant_2_array)]
+    Nblts_selected = np.sum(blts_select)
+
+    uv_object2 = copy.deepcopy(uv_object)
+    uv_object2.select(bls=bls_to_keep)
+    sorted_pairs_object2 = [tuple(sorted(p)) + ('RR',) for p in zip(
+        uv_object2.ant_1_array, uv_object2.ant_2_array)]
+
+    nt.assert_equal(len(new_unique_ants), uv_object2.Nants_data)
+    nt.assert_equal(Nblts_selected, uv_object2.Nblts)
+    for ant in new_unique_ants:
+        nt.assert_true(
+            ant in uv_object2.ant_1_array or ant in uv_object2.ant_2_array)
+    for ant in np.unique(uv_object2.ant_1_array.tolist() + uv_object2.ant_2_array.tolist()):
+        nt.assert_true(ant in new_unique_ants)
+    for bl in sorted_bls_to_keep:
+        nt.assert_true(bl in sorted_pairs_object2)
+    for bl in sorted_pairs_object2:
+        nt.assert_true(bl in sorted_bls_to_keep)
+
+    print old_history + '  Downselected to specific baselines using pyuvdata.'
+    print uv_object2.history
+    nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
+                                           'specific baselines, polarizations using pyuvdata.',
+                                           uv_object2.history))
+
+
     # check that you can use numpy integers with out errors:
     first_ants = map(np.int32, [6, 2, 7, 2, 21, 27, 8])
     second_ants = map(np.int32, [0, 20, 8, 1, 2, 3, 22])

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -483,9 +483,9 @@ def test_select_bls():
     for pair in sorted_pairs_object2:
         nt.assert_true(pair in sorted_pairs_to_keep)
 
-    # nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
-    #                                        'specific baselines using pyuvdata.',
-    #                                        uv_object2.history))
+    nt.assert_true(uvutils.check_histories(old_history + '  Downselected to '
+                                           'specific baselines using pyuvdata.',
+                                           uv_object2.history))
 
     # check that you can use numpy integers with out errors:
     first_ants = map(np.int32, [6, 2, 7, 2, 21, 27, 8])

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1089,14 +1089,13 @@ class UVData(UVBase):
                     bls_blt_inds = np.append(bls_blt_inds, list(wh1))
                     if len(bl) == 3:
                         bl_pols.add(bl[2])
-                if len(wh2) > 0:
+                elif len(wh2) > 0:
                     bls_blt_inds = np.append(bls_blt_inds, list(wh2))
                     if len(bl) == 3:
                         bl_pols.add(bl[2][::-1])  # reverse polarization string
-                if len(wh1) == 0 and len(wh2) == 0:
+                else:
                     raise ValueError('Antenna pair {p} does not have any data '
                                      'associated with it.'.format(p=bl))
-
             if len(bl_pols) > 0:
                 polarizations = list(bl_pols)
 

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -992,12 +992,12 @@ class UVData(UVBase):
 
         if ant_str is not None:
             if not (antenna_nums is None and antenna_names is None
-                    and ant_pairs_nums is None and polarizations is None):
+                    and bls is None and polarizations is None):
                 raise ValueError(
                     'Cannot provide ant_str with antenna_nums, antenna_names, '
-                    'ant_pairs_nums, or polarizations.')
+                    'bls, or polarizations.')
             else:
-                ant_pairs_nums, polarizations = self.parse_ants(ant_str)
+                bls, polarizations = self.parse_ants(ant_str)
 
         # Antennas, times and blt_inds all need to be combined into a set of
         # blts indices to keep.
@@ -1050,7 +1050,7 @@ class UVData(UVBase):
 
         if bls is not None:
             if isinstance(bls, tuple) and (len(bls) == 2 or len(bls) == 3):
-                ant_pairs_nums = [ant_pairs_nums]
+                bls = [bls]
             if not all(isinstance(item, tuple) for item in bls):
                 raise ValueError(
                     'bls must be a list of tuples of antenna numbers (optionally with polarization).')
@@ -1491,7 +1491,7 @@ class UVData(UVBase):
         del(uvfits_obj)
 
     def read_uvfits_data(self, filename, antenna_nums=None, antenna_names=None,
-                         ant_str=None, ant_pairs_nums=None, frequencies=None,
+                         ant_str=None, bls=None, frequencies=None,
                          freq_chans=None, times=None, polarizations=None,
                          blt_inds=None, run_check=True, check_extra=True,
                          run_check_acceptability=True):
@@ -1509,9 +1509,12 @@ class UVData(UVBase):
                 the object (antenna positions and names for the excluded antennas
                 will be retained). This cannot be provided if antenna_nums is
                 also provided.
-            ant_pairs_nums: A list of antenna number tuples (e.g. [(0,1), (3,2)])
-                specifying baselines to include when reading data into the object.
-                Ordering of the numbers within the tuple does not matter.
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
+                to keep in the object. For length-2 tuples, the  ordering of the numbers 
+                within the tuple does not matter. For length-3 tuples, the polarization 
+                string is in the order of the two antennas. If length-3 tuples are 
+                provided, the polarizations argument below must be None.
             ant_str: A string containing information about what antenna numbers
                 and polarizations to include when reading data into the object.
                 Can be 'auto', 'cross', 'all', or combinations of antenna numbers
@@ -1546,7 +1549,7 @@ class UVData(UVBase):
         uvfits_obj = self._convert_to_filetype('uvfits')
         uvfits_obj.read_uvfits_data(filename, antenna_nums=antenna_nums,
                                     antenna_names=antenna_names, ant_str=ant_str,
-                                    ant_pairs_nums=ant_pairs_nums, frequencies=frequencies,
+                                    bls=bls, frequencies=frequencies,
                                     freq_chans=freq_chans, times=times,
                                     polarizations=polarizations, blt_inds=blt_inds,
                                     run_check=run_check, check_extra=check_extra,

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1064,10 +1064,13 @@ class UVData(UVBase):
                 if not all([isinstance(item[2], str) for item in bls]):
                     raise ValueError('The third element in each bl must be a polarization string')
 
-            if n_selects > 0:
-                history_update_string += ', baselines'
+            if ant_str is None:
+                if n_selects > 0:
+                    history_update_string += ', baselines'
+                else:
+                    history_update_string += 'baselines'
             else:
-                history_update_string += 'baselines'
+                history_update_string += 'antenna pairs'
             n_selects += 1
             bls_blt_inds = np.zeros(0, dtype=np.int)
             bl_pols = set()
@@ -1676,7 +1679,7 @@ class UVData(UVBase):
 
     def read_miriad(self, filepath, correct_lat_lon=True, run_check=True,
                     check_extra=True, run_check_acceptability=True, phase_type=None,
-                    antenna_nums=None, ant_str=None, ant_pairs_nums=None,
+                    antenna_nums=None, ant_str=None, bls=None,
                     polarizations=None, time_range=None):
         """
         Read in data from a miriad file.
@@ -1690,13 +1693,15 @@ class UVData(UVBase):
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
             antenna_nums: The antennas numbers to read into the object.
-            ant_pairs_nums: A list of antenna number tuples (e.g. [(0,1), (3,2)])
-                specifying baselines to read into the object. Ordering of the
-                numbers within the tuple does not matter. A single antenna iterable
-                e.g. (1,) is interpreted as all visibilities with that antenna.
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
+                to keep in the object. For length-2 tuples, the  ordering of the numbers 
+                within the tuple does not matter. For length-3 tuples, the polarization 
+                string is in the order of the two antennas. If length-3 tuples are 
+                provided, the polarizations argument below must be None.
             ant_str: A string containing information about what kinds of visibility data
                 to read-in.  Can be 'auto', 'cross', 'all'. Cannot provide ant_str if
-                antenna_nums and/or ant_pairs_nums is not None.
+                antenna_nums and/or bls is not None.
             polarizations: List of polarization integers or strings to read-in.
                 Ex: ['xx', 'yy', ...]
             time_range: len-2 list containing min and max range of times (Julian Date) to read-in.
@@ -1708,7 +1713,7 @@ class UVData(UVBase):
                              run_check=run_check, check_extra=check_extra,
                              run_check_acceptability=run_check_acceptability,
                              phase_type=phase_type, antenna_nums=antenna_nums,
-                             ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
+                             ant_str=ant_str, bls=bls,
                              polarizations=polarizations, time_range=time_range)
             if len(filepath) > 1:
                 for f in filepath[1:]:
@@ -1717,7 +1722,7 @@ class UVData(UVBase):
                                     run_check=run_check, check_extra=check_extra,
                                     run_check_acceptability=run_check_acceptability,
                                     phase_type=phase_type, antenna_nums=antenna_nums,
-                                    ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
+                                    ant_str=ant_str, bls=bls,
                                     polarizations=polarizations, time_range=time_range)
                     self += uv2
                 del(uv2)
@@ -1727,7 +1732,7 @@ class UVData(UVBase):
                                    run_check=run_check, check_extra=check_extra,
                                    run_check_acceptability=run_check_acceptability,
                                    phase_type=phase_type, antenna_nums=antenna_nums,
-                                   ant_str=ant_str, ant_pairs_nums=ant_pairs_nums,
+                                   ant_str=ant_str, bls=bls,
                                    polarizations=polarizations, time_range=time_range)
             self._convert_from_filetype(miriad_obj)
             del(miriad_obj)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1092,7 +1092,7 @@ class UVData(UVBase):
                 if len(wh2) > 0:
                     bls_blt_inds = np.append(bls_blt_inds, list(wh2))
                     if len(bl) == 3:
-                        bl_pols.add(bl[2][::-1]) # reverse polarization string
+                        bl_pols.add(bl[2][::-1])  # reverse polarization string
                 if len(wh1) == 0 and len(wh2) == 0:
                     raise ValueError('Antenna pair {p} does not have any data '
                                      'associated with it.'.format(p=bl))
@@ -1284,11 +1284,11 @@ class UVData(UVBase):
             antenna_names: The antennas names to keep in the object (antenna
                 positions and names for the removed antennas will be retained).
                 This cannot be provided if antenna_nums is also provided.
-            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
-                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
-                to keep in the object. For length-2 tuples, the  ordering of the numbers 
-                within the tuple does not matter. For length-3 tuples, the polarization 
-                string is in the order of the two antennas. If length-3 tuples are provided, 
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to keep in the object. For length-2 tuples, the  ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are provided,
                 the polarizations argument below must be None.
             ant_str: A string containing information about what antenna numbers
                 and polarizations to keep in the object.  Can be 'auto', 'cross', 'all',
@@ -1393,11 +1393,11 @@ class UVData(UVBase):
                 the object (antenna positions and names for the excluded antennas
                 will be retained). This cannot be provided if antenna_nums is
                 also provided. Ignored if read_data is False.
-            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
-                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
-                to keep in the object. For length-2 tuples, the  ordering of the numbers 
-                within the tuple does not matter. For length-3 tuples, the polarization 
-                string is in the order of the two antennas. If length-3 tuples are provided, 
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to keep in the object. For length-2 tuples, the  ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are provided,
                 the polarizations argument below must be None. Ignored if read_data is False.
             ant_str: A string containing information about what antenna numbers
                 and polarizations to include when reading data into the object.
@@ -1512,11 +1512,11 @@ class UVData(UVBase):
                 the object (antenna positions and names for the excluded antennas
                 will be retained). This cannot be provided if antenna_nums is
                 also provided.
-            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
-                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
-                to keep in the object. For length-2 tuples, the  ordering of the numbers 
-                within the tuple does not matter. For length-3 tuples, the polarization 
-                string is in the order of the two antennas. If length-3 tuples are 
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to keep in the object. For length-2 tuples, the  ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are
                 provided, the polarizations argument below must be None.
             ant_str: A string containing information about what antenna numbers
                 and polarizations to include when reading data into the object.
@@ -1693,11 +1693,11 @@ class UVData(UVBase):
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters after reading in the file. Default is True.
             antenna_nums: The antennas numbers to read into the object.
-            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
-                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
-                to keep in the object. For length-2 tuples, the  ordering of the numbers 
-                within the tuple does not matter. For length-3 tuples, the polarization 
-                string is in the order of the two antennas. If length-3 tuples are 
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to keep in the object. For length-2 tuples, the  ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are
                 provided, the polarizations argument below must be None.
             ant_str: A string containing information about what kinds of visibility data
                 to read-in.  Can be 'auto', 'cross', 'all'. Cannot provide ant_str if

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -236,11 +236,11 @@ class UVFITS(UVData):
                 the object (antenna positions and names for the excluded antennas
                 will be retained). This cannot be provided if antenna_nums is
                 also provided. Ignored if read_data is False.
-            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
-                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
-                to keep in the object. For length-2 tuples, the  ordering of the numbers 
-                within the tuple does not matter. For length-3 tuples, the polarization 
-                string is in the order of the two antennas. If length-3 tuples are provided, 
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to keep in the object. For length-2 tuples, the  ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are provided,
                 the polarizations argument below must be None. Ignored if read_data is False.
             ant_str: A string containing information about what antenna numbers
                 and polarizations to include when reading data into the object.
@@ -493,9 +493,12 @@ class UVFITS(UVData):
                 the object (antenna positions and names for the excluded antennas
                 will be retained). This cannot be provided if antenna_nums is
                 also provided.
-            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)])
-                specifying baselines to include when reading data into the object.
-                Ordering of the numbers within the tuple does not matter.
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to keep in the object. For length-2 tuples, the  ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are provided,
+                the polarizations argument below must be None.
             ant_str: A string containing information about what antenna numbers
                 and polarizations to include when reading data into the object.
                 Can be 'auto', 'cross', 'all', or combinations of antenna numbers

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -107,7 +107,7 @@ class UVFITS(UVData):
                                  'one time present')
 
     def _get_data(self, vis_hdu, antenna_nums, antenna_names, ant_str,
-                  ant_pairs_nums, frequencies, freq_chans, times, polarizations,
+                  bls, frequencies, freq_chans, times, polarizations,
                   blt_inds, read_metadata, run_check, check_extra,
                   run_check_acceptability):
         """
@@ -121,7 +121,7 @@ class UVFITS(UVData):
 
         # figure out what data to read in
         blt_inds, freq_inds, pol_inds, history_update_string = \
-            self._select_preprocess(antenna_nums, antenna_names, ant_str, ant_pairs_nums,
+            self._select_preprocess(antenna_nums, antenna_names, ant_str, bls,
                                     frequencies, freq_chans, times, polarizations, blt_inds)
 
         if blt_inds is not None:
@@ -218,7 +218,7 @@ class UVFITS(UVData):
                        run_check_acceptability=run_check_acceptability)
 
     def read_uvfits(self, filename, antenna_nums=None, antenna_names=None,
-                    ant_str=None, ant_pairs_nums=None, frequencies=None,
+                    ant_str=None, bls=None, frequencies=None,
                     freq_chans=None, times=None, polarizations=None, blt_inds=None,
                     read_data=True, read_metadata=True,
                     run_check=True, check_extra=True, run_check_acceptability=True):
@@ -236,10 +236,12 @@ class UVFITS(UVData):
                 the object (antenna positions and names for the excluded antennas
                 will be retained). This cannot be provided if antenna_nums is
                 also provided. Ignored if read_data is False.
-            ant_pairs_nums: A list of antenna number tuples (e.g. [(0,1), (3,2)])
-                specifying baselines to include when reading data into the object.
-                Ordering of the numbers within the tuple does not matter.
-                Ignored if read_data is False.
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of 
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines 
+                to keep in the object. For length-2 tuples, the  ordering of the numbers 
+                within the tuple does not matter. For length-3 tuples, the polarization 
+                string is in the order of the two antennas. If length-3 tuples are provided, 
+                the polarizations argument below must be None. Ignored if read_data is False.
             ant_str: A string containing information about what antenna numbers
                 and polarizations to include when reading data into the object.
                 Can be 'auto', 'cross', 'all', or combinations of antenna numbers
@@ -449,7 +451,7 @@ class UVFITS(UVData):
 
         # Now read in the data
         self._get_data(vis_hdu, antenna_nums, antenna_names, ant_str,
-                       ant_pairs_nums, frequencies, freq_chans, times, polarizations,
+                       bls, frequencies, freq_chans, times, polarizations,
                        blt_inds, False, run_check, check_extra, run_check_acceptability)
 
     def read_uvfits_metadata(self, filename):
@@ -473,7 +475,7 @@ class UVFITS(UVData):
         del(vis_hdu)
 
     def read_uvfits_data(self, filename, antenna_nums=None, antenna_names=None,
-                         ant_str=None, ant_pairs_nums=None, frequencies=None,
+                         ant_str=None, bls=None, frequencies=None,
                          freq_chans=None, times=None, polarizations=None,
                          blt_inds=None, read_metadata=True, run_check=True,
                          check_extra=True, run_check_acceptability=True):
@@ -491,7 +493,7 @@ class UVFITS(UVData):
                 the object (antenna positions and names for the excluded antennas
                 will be retained). This cannot be provided if antenna_nums is
                 also provided.
-            ant_pairs_nums: A list of antenna number tuples (e.g. [(0,1), (3,2)])
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)])
                 specifying baselines to include when reading data into the object.
                 Ordering of the numbers within the tuple does not matter.
             ant_str: A string containing information about what antenna numbers
@@ -528,7 +530,7 @@ class UVFITS(UVData):
         vis_hdu = hdu_list[0]  # assumes the visibilities are in the primary hdu
 
         self._get_data(vis_hdu, antenna_nums, antenna_names, ant_str,
-                       ant_pairs_nums, frequencies, freq_chans, times, polarizations,
+                       bls, frequencies, freq_chans, times, polarizations,
                        blt_inds, read_metadata, run_check, check_extra,
                        run_check_acceptability)
 


### PR DESCRIPTION
Previously, `ant_pair_nums` supported lists like `[(0,1), (2,3)]`. Now `bls` supports lists like `[(0,1,'xx'), (2,3,'yy')]` as well.