### PR TITLE
Add compression filters to write_uvh5 method

### DIFF
--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -109,3 +109,25 @@ def test_UVH5OptionalParameters():
     os.remove(testfile)
 
     return
+
+
+def test_UVH5CompressionOptions():
+    """
+    Test writing data with compression filters
+    """
+    uv_in = UVData()
+    uv_out = UVData()
+    uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    testfile = os.path.join(DATA_PATH, 'test', 'outtest_uvfits_compression.h5')
+
+    # write out and read back in
+    uv_in.write_uvh5(testfile, clobber=True, data_compression="lzf",
+                     flags_compression=None, nsample_compression=None)
+    uv_out.read_uvh5(testfile)
+    nt.assert_equal(uv_in, uv_out)
+
+    # clean up
+    os.remove(testfile)
+
+    return

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1796,7 +1796,9 @@ class UVData(UVBase):
             del(uvh5_obj)
 
     def write_uvh5(self, filename, run_check=True, check_extra=True,
-                   run_check_acceptability=True, clobber=False):
+                   run_check_acceptability=True, clobber=False,
+                   data_compression=None, flags_compression="lzf",
+                   nsample_compression="lzf"):
         """
         Write a UVData object to a UVH5 file.
 
@@ -1809,6 +1811,12 @@ class UVData(UVBase):
             run_check_acceptability: Option to check acceptable range of the values of
                 parameters before writing the file. Default is True.
             clobber: Option to overwrite the file if it already exists. Default is False.
+            data_compression: HDF5 filter to apply when writing the data_array. Default is
+                None (no filter/compression).
+            flags_compression: HDF5 filter to apply when writing the flags_array. Default is
+                the LZF filter.
+            nsample_compression: HDF5 filter to apply when writing the nsample_array. Deafult is
+                the LZF filter.
 
         Returns:
             None
@@ -1817,7 +1825,9 @@ class UVData(UVBase):
         uvh5_obj.write_uvh5(filename, run_check=run_check,
                             check_extra=check_extra,
                             run_check_acceptability=run_check_acceptability,
-                            clobber=clobber)
+                            clobber=clobber, data_compression=data_compression,
+                            flags_compression=flags_compression,
+                            nsample_compression=nsample_compression)
         del(uvh5_obj)
 
     def reorder_pols(self, order=None, run_check=True, check_extra=True,


### PR DESCRIPTION
This PR fixes #350. It does _not_ add the ability to add the bitshuffle filter for writing the `data_array`, but if that functionality is desired, we can add it at a future date. Just adding the LZF filter, built in to all distributions of `h5py`, for the `flag_array` and `nsample_array` can provide significant savings, especially if these arrays are (nearly) uniform.