### PR TITLE
Update docs to reflect uvh5 capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/HERA-Team/pyuvdata.svg?branch=master)](https://travis-ci.org/HERA-Team/pyuvdata)
 [![Coverage Status](https://coveralls.io/repos/github/HERA-Team/pyuvdata/badge.svg?branch=master)](https://coveralls.io/github/HERA-Team/pyuvdata?branch=master)
 
-pyuvdata defines a pythonic interface to interferometric data sets. Currently pyuvdata supports reading and writing of miriad and uvfits files and reading of CASA measurement sets and FHD ([Fast Holographic Deconvolution](https://github.com/EoRImaging/FHD)) visibility save files.
+pyuvdata defines a pythonic interface to interferometric data sets. Currently pyuvdata supports reading and writing of miriad, uvfits, and uvh5 files and reading of CASA measurement sets and FHD ([Fast Holographic Deconvolution](https://github.com/EoRImaging/FHD)) visibility save files.
 
 
 # Motivation
@@ -22,15 +22,20 @@ pyuvdata has three major user classes:
 
 ## UVData Tested File Paths
 * uvfits -> miriad
+* uvfits -> uvh5
 * miriad -> uvfits
+* miriad -> uvh5
 * FHD -> uvfits
 * FHD -> miriad
 * CASA measurement sets -> miriad
 * CASA measurement sets -> uvfits
+* uvh5 -> uvfits
+* uvh5 -> miriad
 
 ## UVData File standard notes
 * miriad is supported for aipy-style analysis, further testing is required for use in the miriad package
 * uvfits conforms to AIPS memo 117 (as of May 2015).  It is tested against FHD, CASA, and AIPS. However AIPS is limited to <80 antennas and CASA imaging does not seem to support >255 antennas.
+* uvh5 is an HDF5-based file format defined by the HERA collaboration, and is defined by a memo (coming soon).
 * FHD (read-only support, tested against MWA and PAPER data)
 * CASA measurement sets (read-only support)
 
@@ -127,5 +132,5 @@ From the source pyuvdata directory run ```nosetests pyuvdata```.
 
 
 # API
-The primary interface to data from python is via the UVData object. It provides import functionality from all supported file formats (UVFITS, Miriad, FHD, CASA measurement sets) and export to UVFITS and Miriad formats and can be interacted with directly. Similarly, the primary calibration and beam interfaces are via the UVCal and UVBeam objects. The attributes of the UVData, UVCal and UVBeam objects are
+The primary interface to data from python is via the UVData object. It provides import functionality from all supported file formats (UVFITS, Miriad, UVH5, FHD, CASA measurement sets) and export to UVFITS, Miriad, and UVH5 formats and can be interacted with directly. Similarly, the primary calibration and beam interfaces are via the UVCal and UVBeam objects. The attributes of the UVData, UVCal and UVBeam objects are
 described in the uvdata_parameters, uvcal_parameters and uvbeam_parameters descriptions at https://pyuvdata.readthedocs.io or [here](https://github.com/HERA-Team/pyuvdata/blob/master/docs).

--- a/README.md
+++ b/README.md
@@ -102,13 +102,14 @@ python setup.py build_ext --inplace
 ## Dependencies
 The numpy and astropy versions are important, so be sure to make sure these are up to date before you install.
 
-For anaconda users, we suggest using conda to install astropy, numpy and scipy and conda-forge
-for pyephem and optionally casacore-python and healpy (e.g. ```conda install -c conda-forge pyephem```).
+For anaconda users, we suggest using conda to install astropy, numpy, scipy, and optionally h5py, and
+conda-forge for pyephem and optionally casacore-python and healpy (e.g. ```conda install -c conda-forge pyephem```).
 
 * numpy >= 1.10
 * scipy
 * astropy >= 1.2
 * pyephem
+* h5py (optional: for reading and writing uvh5 format)
 * casacore-python (optional: for CASA measurement set reading functionality)
 * healpy (optional: working with beams in HEALPix formats)
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -118,6 +118,36 @@ f) CASA -> miriad
   ...    shutil.rmtree(write_file)
   >>> UV.write_miriad(write_file)
 
+g) miriad -> uvh5
+*****************
+::
+
+  >>> from pyuvdata import UVData
+  >>> UV = UVData()
+
+  # This miriad file is known to be a drift scan
+  >>> miriad_file = 'pyuvdata/data/new.uvA'
+  >>> UV.read_miriad(miriad_file)
+
+  # Write out the uvfits file
+  >>> UV.write_uvh5('tutorial.h5')
+
+h) uvfits -> uvh5
+*****************
+::
+
+   >>> from pyuvdata import UVData
+   >>> import os
+   >>> UV = UVData()
+   >>> uvfits_file = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
+   >>> UV.read_uvfits(uvfits_file)
+
+   # Write out the UVH5 file
+   >>> write_file = 'tutorial.h5'
+   >>> if os.path.exists(write_file):
+   ...    os.remove(write_file)
+   >>> UV.write_uvh5(write_file)
+
 UVData: Quick data access
 --------------------------
 A small suite of functions are available to quickly access numpy arrays of data,


### PR DESCRIPTION
This PR fixes #349. It adds how to write uvh5 files to the tutorial, and adds discussion of uvh5 files and installation dependencies to the README.