### PR TITLE
Work on both Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
+  - "3.6"
+
 install:
   # ensure that we have the full tag information available for version.py
   - git fetch --unshallow --tags
@@ -26,7 +28,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda install numpy scipy astropy nose pip h5py
+  - conda install numpy scipy astropy nose pip h5py six
   - conda install -c conda-forge healpy pyephem python-casacore pycodestyle coveralls
   - conda list
 script:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,6 +1,9 @@
 Tutorial
 ========
 
+.. testsetup::
+   from __future__ import absolute_import, division, print_function
+
 ------
 UVData
 ------
@@ -371,8 +374,8 @@ c) Select a few antenna pairs to keep
 
   # note that order of the values in the pair does not matter
   # print all the antenna pairs after the select
-  >>> print(set(zip(UV.ant_1_array, UV.ant_2_array)))
-  set([(0, 6), (0, 21), (0, 2)])
+  >>> print(list(set(zip(UV.ant_1_array, UV.ant_2_array))))
+  [(0, 6), (0, 21), (0, 2)]
 
 d) Select antenna pairs and polarizations using ant_str argument
 ********************************************************************
@@ -454,14 +457,14 @@ all antenna pairs kept in the object will retain data for each specified polariz
   >>> UV.read_uvfits(filename)
 
   # Print the number of antennas and polarizations with data in the original file
-  >>> print(len(UV.get_antpairs()), UV.get_pols())
+  >>> print((len(UV.get_antpairs()), UV.get_pols()))
   (153, ['RR', 'LL', 'RL', 'LR'])
 
   # Apply select to UV object
   >>> UV.select(ant_str='1r_2l,1l_3l,1r_6r')
 
   # Print all the antennas numbers and polarizations with data after the select
-  >>> print(UV.get_antpairs(), UV.get_pols())
+  >>> print((UV.get_antpairs(), UV.get_pols()))
   ([(1, 2), (1, 3), (1, 6)], ['RR', 'LL', 'RL'])
 
 4. Stokes parameter(s):
@@ -539,7 +542,7 @@ a) Add frequencies.
   >>> uv1.select(freq_chans=np.arange(0, 32))
   >>> uv2.select(freq_chans=np.arange(32, 64))
   >>> uv3 = uv1 + uv2
-  >>> print(uv1.Nfreqs, uv2.Nfreqs, uv3.Nfreqs)
+  >>> print((uv1.Nfreqs, uv2.Nfreqs, uv3.Nfreqs))
   (32, 32, 64)
 
 b) Add times.
@@ -559,9 +562,9 @@ b) Add times.
   >>> uv1.select(times=times[0:len(times) // 2])
   >>> uv2.select(times=times[len(times) // 2:])
   >>> uv3 = uv1 + uv2
-  >>> print(uv1.Ntimes, uv2.Ntimes, uv3.Ntimes)
+  >>> print((uv1.Ntimes, uv2.Ntimes, uv3.Ntimes))
   (7, 8, 15)
-  >>> print(uv1.Nblts, uv2.Nblts, uv3.Nblts)
+  >>> print((uv1.Nblts, uv2.Nblts, uv3.Nblts))
   (459, 901, 1360)
 
 c) Adding in place.
@@ -622,7 +625,7 @@ so only some of the expected attributes are filled out
   >>> uv = UVData()
   >>> filename = 'pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits'
   >>> uv.read_uvfits(filename, read_data=False, read_metadata=False)
-  >>> print(uv.Nblts, uv.Nfreqs, uv.Npols)
+  >>> print((uv.Nblts, uv.Nfreqs, uv.Npols))
   (1360, 64, 4)
 
   >>> print(uv.freq_array.size)
@@ -726,7 +729,7 @@ a) Reading a gain calibration file.
   gain
 
   # number of antenna polarizations and polarization type.
-  >>> print(cal.Njones, cal.jones_array)
+  >>> print((cal.Njones, cal.jones_array))
   (1, array([-5]))
 
   # Number of antennas with data
@@ -898,7 +901,7 @@ a) Reading a CST power beam file
   physical
 
   # number of beam polarizations and polarization type.
-  >>> print(beam.Npols, beam.polarization_array)
+  >>> print((beam.Npols, beam.polarization_array))
   (2, array([-5, -6]))
   >>> print(beam.Nfreqs)
   2

--- a/pyuvdata/beamfits.py
+++ b/pyuvdata/beamfits.py
@@ -214,7 +214,7 @@ class BeamFITS(UVBeam):
                                'GROUPS', 'PCOUNT', 'BSCALE', 'BZERO', 'NAXIS',
                                'PTYPE', 'PSCAL', 'PZERO', 'CTYPE', 'CRVAL',
                                'CRPIX', 'CDELT', 'CROTA', 'CUNIT']
-        for key in primary_header.keys():
+        for key in list(primary_header.keys()):
             for sub in std_fits_substrings:
                 if key.find(sub) > -1:
                     primary_header.remove(key)

--- a/pyuvdata/calfits.py
+++ b/pyuvdata/calfits.py
@@ -546,7 +546,7 @@ class CALFITS(UVCal):
                                    'GROUPS', 'PCOUNT', 'BSCALE', 'BZERO', 'NAXIS',
                                    'PTYPE', 'PSCAL', 'PZERO', 'CTYPE', 'CRVAL',
                                    'CRPIX', 'CDELT', 'CROTA', 'CUNIT']
-            for key in hdr.keys():
+            for key in list(hdr.keys()):
                 for sub in std_fits_substrings:
                     if key.find(sub) > -1:
                         hdr.remove(key)

--- a/pyuvdata/fhd.py
+++ b/pyuvdata/fhd.py
@@ -20,7 +20,8 @@ def get_fhd_history(settings_file, return_user=False):
 
     Includes information about the command line call, the user, machine name and date
     """
-    settings_lines = open(settings_file, 'r').readlines()
+    with open(settings_file, 'r') as f:
+        settings_lines = f.readlines()
     main_loc = None
     command_loc = None
     obs_loc = None

--- a/pyuvdata/fhd.py
+++ b/pyuvdata/fhd.py
@@ -211,7 +211,7 @@ class FHD(UVData):
 
         self.Nants_data = int(len(np.unique(self.ant_1_array.tolist() + self.ant_2_array.tolist())))
 
-        self.antenna_names = bl_info['TILE_NAMES'][0].tolist()
+        self.antenna_names = [uvutils.bytes_to_str(b) for b in bl_info['TILE_NAMES'][0].tolist()]
         self.Nants_telescope = len(self.antenna_names)
         self.antenna_numbers = np.arange(self.Nants_telescope)
 

--- a/pyuvdata/fhd_cal.py
+++ b/pyuvdata/fhd_cal.py
@@ -92,7 +92,7 @@ class FHDCal(UVCal):
                                float(cal_data['max_cal_baseline'][0])]
 
         galaxy_model = cal_data['skymodel'][0]['galaxy_model'][0]
-        if isinstance(galaxy_model, six.binary_type): # In Python 3, we sometimes get Unicode, sometimes bytes
+        if isinstance(galaxy_model, six.binary_type):  # In Python 3, we sometimes get Unicode, sometimes bytes
             galaxy_model = uvutils.bytes_to_str(galaxy_model)
         if galaxy_model == 0:
             galaxy_model = None

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import numpy as np
 import copy
+import six
 import warnings
 from .uvdata import UVData
 from . import telescopes as uvtel

--- a/pyuvdata/miriad.py
+++ b/pyuvdata/miriad.py
@@ -244,8 +244,8 @@ class Miriad(UVData):
                     raise ValueError(
                         'bls must be a list of tuples of antenna numbers (optionally with polarization).')
                 if all([len(item) == 2 for item in bls]):
-                    if not all([isinstance(item[0], (int, long, np.integer)) for item in bls]
-                               + [isinstance(item[1], (int, long, np.integer)) for item in bls]):
+                    if not all([isinstance(item[0], six.integer_types + (np.integer,)) for item in bls]
+                               + [isinstance(item[1], six.integer_types + (np.integer,)) for item in bls]):
                         raise ValueError(
                             'bls must be a list of tuples of antenna numbers (optionally with polarization).')
                 elif all([len(item) == 3 for item in bls]):
@@ -648,7 +648,7 @@ class Miriad(UVData):
                               'file with write_miriad to ensure future '
                               'compatibility'.format(file=filepath))
                 ant_name_flt = uv['antnames']
-                ant_name_list = [('%x' % elem.astype(np.int64)).decode('hex') for elem in ant_name_flt]
+                ant_name_list = [str(elem.astype(np.int64)) for elem in ant_name_flt]
                 self.antenna_names = ant_name_list
 
         except(KeyError):

--- a/pyuvdata/src/miriad_wrap.h
+++ b/pyuvdata/src/miriad_wrap.h
@@ -48,11 +48,11 @@
         PyErr_Format(PyExc_ValueError, "expected a string"); \
         return NULL; }
 #define CHK_INT(o) \
-    if (!PyInt_Check(o)) { \
+    if (!PyInt_Check(o) && !PyIndex_Check(o)) {            \
         PyErr_Format(PyExc_ValueError, "expected an int"); \
         return NULL; }
 #define CHK_LONG(o) \
-    if (!PyLong_Check(o)) { \
+    if (!PyLong_Check(o) && !PyIndex_Check(o)) { \
         PyErr_Format(PyExc_ValueError, "expected a long"); \
         return NULL; }
 #define CHK_FLOAT(o) \

--- a/pyuvdata/tests/test_uvbase.py
+++ b/pyuvdata/tests/test_uvbase.py
@@ -41,7 +41,7 @@ class UVTest(UVBase):
 
         self._intlist = uvp.UVParameter('intlist', description='integer list',
                                         form=('int1',), expected_type=int,
-                                        value=[i for i in np.arange(self._int1.value)])
+                                        value=list(range(self._int1.value)))
         super(UVTest, self).__init__()
 
 

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -455,6 +455,13 @@ def test_select_antennas():
                      antenna_nums=ants_to_keep, antenna_names=ant_names)
 
 
+def sort_bl(p):
+    """Sort a tuple that starts with a pair of antennas, and may have stuff after."""
+    if p[1] >= p[0]:
+        return p
+    return (p[1], p[0]) + p[2:]
+
+
 def test_select_bls():
     uv_object = UVData()
     testfile = os.path.join(
@@ -466,18 +473,18 @@ def test_select_bls():
     second_ants = [0, 20, 8, 1, 2, 3, 22]
     new_unique_ants = np.unique(first_ants + second_ants)
     ant_pairs_to_keep = list(zip(first_ants, second_ants))
-    sorted_pairs_to_keep = [tuple(sorted(p)) for p in ant_pairs_to_keep]
+    sorted_pairs_to_keep = [sort_bl(p) for p in ant_pairs_to_keep]
 
-    sorted_pairs_object = [tuple(sorted(p)) for p in zip(
+    sorted_pairs_object = [sort_bl(p) for p in zip(
         uv_object.ant_1_array, uv_object.ant_2_array)]
 
-    blts_select = [tuple(sorted((a1, a2))) in sorted_pairs_to_keep for (a1, a2) in
+    blts_select = [sort_bl((a1, a2)) in sorted_pairs_to_keep for (a1, a2) in
                    zip(uv_object.ant_1_array, uv_object.ant_2_array)]
     Nblts_selected = np.sum(blts_select)
 
     uv_object2 = copy.deepcopy(uv_object)
     uv_object2.select(bls=ant_pairs_to_keep)
-    sorted_pairs_object2 = [tuple(sorted(p)) for p in zip(
+    sorted_pairs_object2 = [sort_bl(p) for p in zip(
         uv_object2.ant_1_array, uv_object2.ant_2_array)]
 
     nt.assert_equal(len(new_unique_ants), uv_object2.Nants_data)
@@ -501,19 +508,19 @@ def test_select_bls():
     second_ants = [0, 20, 8, 1, 2, 3, 22]
     pols = ['RR', 'RR', 'RR', 'RR', 'RR', 'RR', 'RR']
     new_unique_ants = np.unique(first_ants + second_ants)
-    bls_to_keep = zip(first_ants, second_ants, pols)
-    sorted_bls_to_keep = [tuple(sorted(p)) for p in bls_to_keep]
+    bls_to_keep = list(zip(first_ants, second_ants, pols))
+    sorted_bls_to_keep = [sort_bl(p) for p in bls_to_keep]
 
-    sorted_pairs_object = [tuple(sorted(p)) for p in zip(
+    sorted_pairs_object = [sort_bl(p) for p in zip(
         uv_object.ant_1_array, uv_object.ant_2_array)]
 
-    blts_select = [tuple(sorted((a1, a2, 'RR'))) in sorted_bls_to_keep for (a1, a2) in
+    blts_select = [sort_bl((a1, a2, 'RR')) in sorted_bls_to_keep for (a1, a2) in
                    zip(uv_object.ant_1_array, uv_object.ant_2_array)]
     Nblts_selected = np.sum(blts_select)
 
     uv_object2 = copy.deepcopy(uv_object)
     uv_object2.select(bls=bls_to_keep)
-    sorted_pairs_object2 = [tuple(sorted(p)) + ('RR',) for p in zip(
+    sorted_pairs_object2 = [sort_bl(p) + ('RR',) for p in zip(
         uv_object2.ant_1_array, uv_object2.ant_2_array)]
 
     nt.assert_equal(len(new_unique_ants), uv_object2.Nants_data)
@@ -538,7 +545,7 @@ def test_select_bls():
     ant_pairs_to_keep = list(zip(first_ants, second_ants))
 
     uv_object2 = uv_object.select(bls=ant_pairs_to_keep, inplace=False)
-    sorted_pairs_object2 = [tuple(sorted(p)) for p in zip(
+    sorted_pairs_object2 = [sort_bl(p) for p in zip(
         uv_object2.ant_1_array, uv_object2.ant_2_array)]
 
     nt.assert_equal(len(new_unique_ants), uv_object2.Nants_data)
@@ -559,7 +566,7 @@ def test_select_bls():
 
     # check that you can specify a single pair without errors
     uv_object2.select(bls=(0, 6))
-    sorted_pairs_object2 = [tuple(sorted(p)) for p in zip(
+    sorted_pairs_object2 = [sort_bl(p) for p in zip(
         uv_object2.ant_1_array, uv_object2.ant_2_array)]
     nt.assert_equal(list(set(sorted_pairs_object2)), [(0, 6)])
 
@@ -755,7 +762,7 @@ def test_select():
     ants_to_keep = np.array([11, 6, 20, 26, 2, 27, 3, 7, 14])
 
     ant_pairs_to_keep = [(2, 11), (20, 26), (6, 7), (3, 27), (14, 6)]
-    sorted_pairs_to_keep = [tuple(sorted(p)) for p in ant_pairs_to_keep]
+    sorted_pairs_to_keep = [sort_bl(p) for p in ant_pairs_to_keep]
 
     freqs_to_keep = uv_object.freq_array[0, np.arange(31, 39)]
 
@@ -768,7 +775,7 @@ def test_select():
     blts_blt_select = [i in blt_inds for i in np.arange(uv_object.Nblts)]
     blts_ant_select = [(a1 in ants_to_keep) & (a2 in ants_to_keep) for (a1, a2) in
                        zip(uv_object.ant_1_array, uv_object.ant_2_array)]
-    blts_pair_select = [tuple(sorted((a1, a2))) in sorted_pairs_to_keep for (a1, a2) in
+    blts_pair_select = [sort_bl((a1, a2)) in sorted_pairs_to_keep for (a1, a2) in
                         zip(uv_object.ant_1_array, uv_object.ant_2_array)]
     blts_time_select = [t in times_to_keep for t in uv_object.time_array]
     Nblts_select = np.sum([bi & (ai | pi) & ti for (bi, ai, pi, ti) in

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -19,6 +19,7 @@ from pyuvdata.data import DATA_PATH
 if six.PY2:
     nt.assert_count_equal = nt.assert_items_equal
 
+
 class TestUVDataInit(object):
     def setUp(self):
         """Setup for basic parameter, property and iterator tests."""

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -9,12 +9,15 @@ import nose.tools as nt
 import os
 import numpy as np
 import copy
+import six
 import ephem
 from pyuvdata import UVData
 import pyuvdata.utils as uvutils
 import pyuvdata.tests as uvtest
 from pyuvdata.data import DATA_PATH
 
+if six.PY2:
+    nt.assert_count_equal = nt.assert_items_equal
 
 class TestUVDataInit(object):
     def setUp(self):
@@ -1713,7 +1716,7 @@ def test_get_pols():
                          message='Telescope EVLA is not')
     pols = uv.get_pols()
     pols_data = ['RR', 'LL', 'LR', 'RL']
-    nt.assert_items_equal(pols, pols_data)
+    nt.assert_count_equal(pols, pols_data)
 
 
 def test_get_feedpols():
@@ -1725,7 +1728,7 @@ def test_get_feedpols():
                          message='Telescope EVLA is not')
     pols = uv.get_feedpols()
     pols_data = ['R', 'L']
-    nt.assert_items_equal(pols, pols_data)
+    nt.assert_count_equal(pols, pols_data)
 
     # Test break when pseudo-Stokes visibilities are present
     uv.polarization_array[0] = 1  # pseudo-Stokes I
@@ -1748,13 +1751,13 @@ def test_parse_ants():
     # Auto correlations
     ant_str = 'auto'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
-    nt.assert_items_equal(ant_pairs_nums, [])
+    nt.assert_count_equal(ant_pairs_nums, [])
     nt.assert_is_instance(polarizations, type(None))
 
     # Cross correlations
     ant_str = 'cross'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
-    nt.assert_items_equal(uv.get_antpairs(), ant_pairs_nums)
+    nt.assert_count_equal(uv.get_antpairs(), ant_pairs_nums)
     nt.assert_is_instance(polarizations, type(None))
 
     # pseudo-Stokes params
@@ -1762,7 +1765,7 @@ def test_parse_ants():
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     pols_expected = [4, 3, 2, 1]
     nt.assert_is_instance(ant_pairs_nums, type(None))
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Unparsible string
     ant_str = 'none'
@@ -1775,7 +1778,7 @@ def test_parse_ants():
                           (0, 11), (0, 14), (0, 18), (0, 19), (0, 20),
                           (0, 21), (0, 22), (0, 23), (0, 24), (0, 26),
                           (0, 27)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Single antenna number not in the data
@@ -1798,14 +1801,14 @@ def test_parse_ants():
                           (21, 22), (21, 26), (22, 23), (22, 24),
                           (22, 26), (22, 27), (23, 26), (24, 26),
                           (26, 27)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Single baseline
     ant_str = '1_3'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 3)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Single baseline with polarization
@@ -1813,8 +1816,8 @@ def test_parse_ants():
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 3)]
     pols_expected = [-4]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Single baseline with single polarization in first entry
     ant_str = '1l_3,2x_3'
@@ -1824,8 +1827,8 @@ def test_parse_ants():
                                                          message='Warning: Polarization')
     ant_pairs_expected = [(1, 3), (2, 3)]
     pols_expected = [-2, -4]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Single baseline with single polarization in last entry
     ant_str = '1_3l,2_3x'
@@ -1835,14 +1838,14 @@ def test_parse_ants():
                                                          message='Warning: Polarization')
     ant_pairs_expected = [(1, 3), (2, 3)]
     pols_expected = [-2, -3]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Multiple baselines as list
     ant_str = '1_2,1_3,1_11'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 2), (1, 3), (1, 11)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Multiples baselines with polarizations as list
@@ -1850,21 +1853,21 @@ def test_parse_ants():
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 2), (1, 3), (1, 11)]
     pols_expected = [-1, -2, -3]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Specific baselines with parenthesis
     ant_str = '(1,3)_11'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 11), (3, 11)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Specific baselines with parenthesis
     ant_str = '1_(3,11)'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 3), (1, 11)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Antenna numbers with polarizations
@@ -1872,14 +1875,14 @@ def test_parse_ants():
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 3), (1, 6), (2, 3), (2, 6)]
     pols_expected = [-1, -2, -3, -4]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Antenna numbers with - for avoidance
     ant_str = '1_(-3,11)'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 11)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Remove specific antenna number
@@ -1888,13 +1891,13 @@ def test_parse_ants():
     ant_pairs_expected = [(0, 1), (1, 2), (1, 6), (1, 7), (1, 8), (1, 11),
                           (1, 14), (1, 18), (1, 19), (1, 20), (1, 21),
                           (1, 22), (1, 23), (1, 24), (1, 26), (1, 27)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Remove specific baseline (same expected antenna pairs as above example)
     ant_str = '1,-1_3'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Antenna numbers with polarizations and - for avoidance
@@ -1902,16 +1905,16 @@ def test_parse_ants():
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 11)]
     pols_expected = [-2]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Antenna numbers and pseudo-Stokes parameters
     ant_str = '(1l,2r)_(3l,6r),pI,pq'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(1, 3), (1, 6), (2, 3), (2, 6)]
     pols_expected = [2, 1, -1, -2, -3, -4]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
-    nt.assert_items_equal(polarizations, pols_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(polarizations, pols_expected)
 
     # Test ant_str='auto' on file with auto correlations
     uv = UVData()
@@ -1922,28 +1925,28 @@ def test_parse_ants():
     ant_str = 'auto'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(9, 9), (10, 10), (20, 20)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Test cross correlation extraction on data with auto + cross
     ant_str = 'cross'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(9, 10), (9, 20), (10, 20)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Remove only polarization of single baseline
     ant_str = 'all,-9x_10x'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(9, 9), (9, 20), (10, 10), (10, 20), (20, 20)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
     # Test appending all to beginning of strings that start with -
     ant_str = '-9'
     ant_pairs_nums, polarizations = uv.parse_ants(ant_str)
     ant_pairs_expected = [(10, 10), (10, 20), (20, 20)]
-    nt.assert_items_equal(ant_pairs_nums, ant_pairs_expected)
+    nt.assert_count_equal(ant_pairs_nums, ant_pairs_expected)
     nt.assert_is_instance(polarizations, type(None))
 
 
@@ -1977,8 +1980,8 @@ def test_select_with_ant_str():
     # All baselines
     ant_str = 'all'
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), uv.get_antpairs())
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), uv.get_antpairs())
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Auto correlations
     ant_str = 'auto'
@@ -1988,8 +1991,8 @@ def test_select_with_ant_str():
     # Cross correlations
     ant_str = 'cross'
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), uv.get_antpairs())
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), uv.get_antpairs())
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
     # All baselines in data are cross correlations
 
     # pseudo-Stokes params
@@ -2006,8 +2009,8 @@ def test_select_with_ant_str():
                  (0, 14), (0, 18), (0, 19), (0, 20), (0, 21), (0, 22),
                  (0, 23), (0, 24), (0, 26), (0, 27)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Single antenna number not present in data
     ant_str = '10'
@@ -2024,23 +2027,23 @@ def test_select_with_ant_str():
                  (22, 23), (22, 24), (22, 26), (22, 27), (23, 26),
                  (24, 26), (26, 27)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Single baseline
     ant_str = '1_3'
     ant_pairs = [(1, 3)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Single baseline with polarization
     ant_str = '1l_3r'
     ant_pairs = [(1, 3)]
     pols = ['LR']
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), pols)
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), pols)
 
     # Single baseline with single polarization in first entry
     ant_str = '1l_3,2x_3'
@@ -2053,8 +2056,8 @@ def test_select_with_ant_str():
     ant_pairs = [(1, 3), (2, 3)]
     pols = ['LL', 'LR']
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), pols)
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), pols)
 
     # Single baseline with single polarization in last entry
     ant_str = '1_3l,2_3x'
@@ -2067,8 +2070,8 @@ def test_select_with_ant_str():
     ant_pairs = [(1, 3), (2, 3)]
     pols = ['LL', 'RL']
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), pols)
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), pols)
 
     # Multiple baselines as list
     ant_str = '1_2,1_3,1_10'
@@ -2077,51 +2080,51 @@ def test_select_with_ant_str():
                                {'ant_str': ant_str, 'inplace': inplace},
                                nwarnings=1, message='Warning: Antenna')
     ant_pairs = [(1, 2), (1, 3)]
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Multiples baselines with polarizations as list
     ant_str = '1r_2l,1l_3l,1r_11r'
     ant_pairs = [(1, 2), (1, 3), (1, 11)]
     pols = ['RR', 'LL', 'RL']
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), pols)
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), pols)
 
     # Specific baselines with parenthesis
     ant_str = '(1,3)_11'
     ant_pairs = [(1, 11), (3, 11)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Specific baselines with parenthesis
     ant_str = '1_(3,11)'
     ant_pairs = [(1, 3), (1, 11)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Antenna numbers with polarizations
     ant_str = '(1l,2r)_(3l,6r)'
     ant_pairs = [(1, 3), (1, 6), (2, 3), (2, 6)]
     pols = ['RR', 'LL', 'RL', 'LR']
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), pols)
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), pols)
 
     # Antenna numbers with - for avoidance
     ant_str = '1_(-3,11)'
     ant_pairs = [(1, 11)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     ant_str = '(-1,3)_11'
     ant_pairs = [(3, 11)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Remove specific antenna number
     ant_str = '1,-3'
@@ -2129,8 +2132,8 @@ def test_select_with_ant_str():
                  (1, 14), (1, 18), (1, 19), (1, 20), (1, 21),
                  (1, 22), (1, 23), (1, 24), (1, 26), (1, 27)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Remove specific baseline
     ant_str = '1,-1_3'
@@ -2138,24 +2141,24 @@ def test_select_with_ant_str():
                  (1, 14), (1, 18), (1, 19), (1, 20), (1, 21),
                  (1, 22), (1, 23), (1, 24), (1, 26), (1, 27)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Antenna numbers with polarizations and - for avoidance
     ant_str = '1l_(-3r,11l)'
     ant_pairs = [(1, 11)]
     pols = ['LL']
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), pols)
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), pols)
 
     # Test pseudo-Stokes params with select
     ant_str = 'pi,pQ'
     pols = ['pQ', 'pI']
     uv.polarization_array = np.array([4, 3, 2, 1])
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), uv.get_antpairs())
-    nt.assert_items_equal(uv2.get_pols(), pols)
+    nt.assert_count_equal(uv2.get_antpairs(), uv.get_antpairs())
+    nt.assert_count_equal(uv2.get_pols(), pols)
 
     # Test ant_str = 'auto' on file with auto correlations
     uv = UVData()
@@ -2166,29 +2169,29 @@ def test_select_with_ant_str():
     ant_str = 'auto'
     ant_pairs = [(9, 9), (10, 10), (20, 20)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Test cross correlation extraction on data with auto + cross
     ant_str = 'cross'
     ant_pairs = [(9, 10), (9, 20), (10, 20)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Remove only polarization of single baseline
     ant_str = 'all,-9x_10x'
     ant_pairs = [(9, 9), (9, 20), (10, 10), (10, 20), (20, 20)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
     # Test appending all to beginning of strings that start with -
     ant_str = '-9'
     ant_pairs = [(10, 10), (10, 20), (20, 20)]
     uv2 = uv.select(ant_str=ant_str, inplace=inplace)
-    nt.assert_items_equal(uv2.get_antpairs(), ant_pairs)
-    nt.assert_items_equal(uv2.get_pols(), uv.get_pols())
+    nt.assert_count_equal(uv2.get_antpairs(), ant_pairs)
+    nt.assert_count_equal(uv2.get_pols(), uv.get_pols())
 
 
 def test_juldate2ephem():

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -17,6 +17,14 @@ e_squared = 6.69437999014e-3
 e_prime_squared = 6.73949674228e-3
 
 
+if six.PY2:
+    str_to_bytes = lambda s: s
+    bytes_to_str = lambda b: b
+else:
+    str_to_bytes = lambda s: s.encode('utf8')
+    bytes_to_str = lambda b: b.decode('utf8')
+
+
 def LatLonAlt_from_XYZ(xyz):
     """
     Calculate lat/lon/alt from ECEF x,y,z.

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -18,11 +18,17 @@ e_prime_squared = 6.73949674228e-3
 
 
 if six.PY2:
-    str_to_bytes = lambda s: s
-    bytes_to_str = lambda b: b
+    def str_to_bytes(s):
+        return s
+
+    def bytes_to_str(b):
+        return b
 else:
-    str_to_bytes = lambda s: s.encode('utf8')
-    bytes_to_str = lambda b: b.decode('utf8')
+    def str_to_bytes(s):
+        return s.encode('utf8')
+
+    def bytes_to_str(b):
+        return b.decode('utf8')
 
 
 def LatLonAlt_from_XYZ(xyz):

--- a/pyuvdata/uvbase.py
+++ b/pyuvdata/uvbase.py
@@ -13,7 +13,7 @@ from . import parameter as uvp
 from . import version as uvversion
 
 
-def _warning(msg, *a):
+def _warning(msg, *a, **kwargs):
     """Improve the printing of user warnings."""
     return str(msg) + '\n'
 

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -511,7 +511,7 @@ class UVData(UVBase):
             integer baseline number corresponding to the two antenna numbers.
         """
         ant1, ant2 = np.int64((ant1, ant2))
-        if self.Nants_telescope > 2048:
+        if self.Nants_telescope is not None and self.Nants_telescope > 2048:
             raise Exception('cannot convert ant1, ant2 to a baseline index '
                             'with Nants={Nants}>2048.'
                             .format(Nants=self.Nants_telescope))

--- a/pyuvdata/uvfits.py
+++ b/pyuvdata/uvfits.py
@@ -352,7 +352,7 @@ class UVFITS(UVData):
                                    'GROUPS', 'PCOUNT', 'BSCALE', 'BZERO', 'NAXIS',
                                    'PTYPE', 'PSCAL', 'PZERO', 'CTYPE', 'CRVAL',
                                    'CRPIX', 'CDELT', 'CROTA', 'CUNIT', 'DATE-OBS']
-            for key in vis_hdr.keys():
+            for key in list(vis_hdr.keys()):
                 for sub in std_fits_substrings:
                     if key.find(sub) > -1:
                         vis_hdr.remove(key)

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -9,8 +9,21 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import os
+import six
 from .uvdata import UVData
 from . import utils as uvutils
+
+
+def str_to_bytes(s):
+    if six.PY2:
+        return s
+    return s.encode('utf8')
+
+def bytes_to_str(b):
+    if six.PY2:
+        return b
+    return b.decode('utf8')
+
 
 
 class UVH5(UVData):
@@ -111,7 +124,7 @@ class UVH5(UVData):
         self.Nants_telescope = int(header['Nants_telescope'].value)
         self.ant_1_array = header['ant_1_array'].value
         self.ant_2_array = header['ant_2_array'].value
-        self.antenna_names = list(header['antenna_names'].value)
+        self.antenna_names = [bytes_to_str(n) for n in header['antenna_names'].value]
         self.antenna_numbers = header['antenna_numbers'].value
 
         # get baseline array
@@ -234,7 +247,7 @@ class UVH5(UVData):
         header['Npols'] = self.Npols
         header['Nspws'] = self.Nspws
         header['Ntimes'] = self.Ntimes
-        header['antenna_names'] = self.antenna_names
+        header['antenna_names'] = [str_to_bytes(n) for n in self.antenna_names]
         header['antenna_numbers'] = self.antenna_numbers
         header['uvw_array'] = self.uvw_array
         header['vis_units'] = self.vis_units

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -13,7 +13,6 @@ from .uvdata import UVData
 from . import utils as uvutils
 
 
-
 class UVH5(UVData):
     """
     Defines an HDF5-specific subclass of UVData for reading and writing uvh5 files.

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -9,20 +9,8 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import os
-import six
 from .uvdata import UVData
 from . import utils as uvutils
-
-
-def str_to_bytes(s):
-    if six.PY2:
-        return s
-    return s.encode('utf8')
-
-def bytes_to_str(b):
-    if six.PY2:
-        return b
-    return b.decode('utf8')
 
 
 
@@ -124,7 +112,7 @@ class UVH5(UVData):
         self.Nants_telescope = int(header['Nants_telescope'].value)
         self.ant_1_array = header['ant_1_array'].value
         self.ant_2_array = header['ant_2_array'].value
-        self.antenna_names = [bytes_to_str(n) for n in header['antenna_names'].value]
+        self.antenna_names = [uvutils.bytes_to_str(n) for n in header['antenna_names'].value]
         self.antenna_numbers = header['antenna_numbers'].value
 
         # get baseline array
@@ -247,7 +235,7 @@ class UVH5(UVData):
         header['Npols'] = self.Npols
         header['Nspws'] = self.Nspws
         header['Ntimes'] = self.Ntimes
-        header['antenna_names'] = [str_to_bytes(n) for n in self.antenna_names]
+        header['antenna_names'] = [uvutils.str_to_bytes(n) for n in self.antenna_names]
         header['antenna_numbers'] = self.antenna_numbers
         header['uvw_array'] = self.uvw_array
         header['vis_units'] = self.vis_units

--- a/pyuvdata/version.py
+++ b/pyuvdata/version.py
@@ -34,7 +34,8 @@ def construct_version_info():
         return u
 
     version_file = os.path.join(pyuvdata_dir, 'VERSION')
-    version = open(version_file).read().strip()
+    with open(version_file) as f:
+        version = f.read().strip()
 
     try:
         git_origin = get_git_output(['config', '--get', 'remote.origin.url'], capture_stderr=True)


### PR DESCRIPTION
Let's see if we can get the test suite passing on Python 3.

## Superseded:

At the moment, no work done here except to turn on the Python 3 CI.

The errors are dominaeted by a mode that looks pretty innocuous; it looks like there are cases where Python is starting to complain about files not being explicitly closed, which makes the tests that count warnings fail:

```
FAIL: Test writing data with compression filters
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/a/lib/python3.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/a/hera/pyuvdata/pyuvdata/tests/test_uvh5.py", line 127, in test_UVH5CompressionOptions
    uvtest.checkWarnings(uv_in.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
  File "/a/hera/pyuvdata/pyuvdata/tests/__init__.py", line 101, in checkWarnings
    assert(False)
AssertionError: 
-------------------- >> begin captured stdout << ---------------------
wrong number of warnings. Expected number was 1, actual number was 2.
warning 0 is: {message : UserWarning('Telescope EVLA is not in known_telescopes.',), category : 'UserWarning', filename : '/a/hera/pyuvdata/pyuvdata/uvfits.py', lineno : 443, line : None}
warning 1 is: {message : ResourceWarning("unclosed file <_io.FileIO name='/a/hera/pyuvdata/pyuvdata/data/day2_TDEM0003_10s_norx_1src_1spw.uvfits' mode='rb' closefd=True>",), category : 'ResourceWarning', filename : '/a/hera/pyuvdata/pyuvdata/uvdata.py', lineno : 1480, line : None}
```