### PR TITLE
Partial I/O for uvh5 files

### DIFF
--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -738,6 +738,11 @@ def test_UVH5PartialWriteErrors():
     nt.assert_raises(AssertionError, partial_uvh5.write_uvh5_part, partial_testfile, data[:, :, :, 0],
                      flags[:, :, :, 0], nsamples[:, :, :, 0])
 
+    # initialize a file on disk, and pass in a different object so check_header fails
+    empty_uvd = UVData()
+    nt.assert_raises(AssertionError, empty_uvd.write_uvh5_part, partial_testfile, data,
+                     flags, nsamples, bls=key)
+
     # clean up
     os.remove(testfile)
     os.remove(partial_testfile)

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -168,3 +168,72 @@ def test_UVH5ReadMultiple_files():
     os.remove(testfile2)
 
     return
+
+
+def test_UVH5PartialRead():
+    """
+    Test reading in only part of a dataset from disk
+    """
+    uvh5_uv = UVData()
+    uvh5_uv2 = UVData()
+    uvfits_file = os.path.join(DATA_PATH, 'day2_TDEM0003_10s_norx_1src_1spw.uvfits')
+    uvtest.checkWarnings(uvh5_uv.read_uvfits, [uvfits_file], message='Telescope EVLA is not')
+    testfile = os.path.join(DATA_PATH, 'test', 'outtest.h5')
+    uvh5_uv.write_uvh5(testfile, clobber=True)
+
+    # select on antennas
+    ants_to_keep = np.array([0, 19, 11, 24, 3, 23, 1, 20, 21])
+    uvh5_uv.read_uvh5(testfile, antenna_nums=ants_to_keep)
+    uvh5_uv2.read_uvh5(testfile)
+    uvh5_uv2.select(antenna_nums=ants_to_keep)
+    nt.assert_equal(uvh5_uv, uvh5_uv2)
+
+    # select on frequency channels
+    chans_to_keep = np.arange(12, 22)
+    uvh5_uv.read_uvh5(testfile, freq_chans=chans_to_keep)
+    uvh5_uv2.read_uvh5(testfile)
+    uvh5_uv2.select(freq_chans=chans_to_keep)
+    nt.assert_equal(uvh5_uv, uvh5_uv2)
+
+    # select on pols
+    pols_to_keep = [-1, -2]
+    uvh5_uv.read_uvh5(testfile, polarizations=pols_to_keep)
+    uvh5_uv2.read_uvh5(testfile)
+    uvh5_uv2.select(polarizations=pols_to_keep)
+    nt.assert_equal(uvh5_uv, uvh5_uv2)
+
+    # now test selecting on multiple axes
+    # frequencies first
+    uvh5_uv.read_uvh5(testfile, antenna_nums=ants_to_keep,
+                      freq_chans=chans_to_keep,
+                      polarizations=pols_to_keep)
+    uvh5_uv2.read_uvh5(testfile)
+    uvh5_uv2.select(antenna_nums=ants_to_keep, freq_chans=chans_to_keep,
+                    polarizations=pols_to_keep)
+    nt.assert_equal(uvh5_uv, uvh5_uv2)
+
+    # baselines first
+    ants_to_keep = np.array([0, 1])
+    uvh5_uv.read_uvh5(testfile, antenna_nums=ants_to_keep,
+                      freq_chans=chans_to_keep,
+                      polarizations=pols_to_keep)
+    uvh5_uv2.read_uvh5(testfile)
+    uvh5_uv2.select(antenna_nums=ants_to_keep, freq_chans=chans_to_keep,
+                    polarizations=pols_to_keep)
+    nt.assert_equal(uvh5_uv, uvh5_uv2)
+
+    # polarizations first
+    ants_to_keep = np.array([0, 1, 2, 3, 6, 7, 8, 11, 14, 18, 19, 20, 21, 22])
+    chans_to_keep = np.arange(12, 64)
+    uvh5_uv.read_uvh5(testfile, antenna_nums=ants_to_keep,
+                      freq_chans=chans_to_keep,
+                      polarizations=pols_to_keep)
+    uvh5_uv2.read_uvh5(testfile)
+    uvh5_uv2.select(antenna_nums=ants_to_keep, freq_chans=chans_to_keep,
+                    polarizations=pols_to_keep)
+    nt.assert_equal(uvh5_uv, uvh5_uv2)
+
+    # clean up
+    os.remove(testfile)
+
+    return

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -426,6 +426,40 @@ def test_UVH5PartialWriteIrregular():
     partial_uvh5_file.read_uvh5(partial_testfile)
     nt.assert_equal(partial_uvh5_file, partial_uvh5)
 
+    # do it again, with a single frequency
+    # reinitialize
+    partial_uvh5 = copy.deepcopy(full_uvh5)
+    partial_uvh5.data_array = None
+    partial_uvh5.flag_array = None
+    partial_uvh5.nsample_array = None
+
+    # initialize file on disk
+    partial_testfile = os.path.join(DATA_PATH, 'test', 'outtest_partial.h5')
+    initialize_with_zeros(partial_uvh5, partial_testfile)
+
+    # make a mostly empty object in memory to match what we'll write to disk
+    partial_uvh5.data_array = np.zeros_like(full_uvh5.data_array, dtype=np.complex64)
+    partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
+    partial_uvh5.nsample_array = np.zeros_like(full_uvh5.nsample_array, dtype=np.float32)
+
+    # write a single freq to file
+    freq_inds = np.arange(1)
+    data = full_uvh5.data_array[:, :, freq_inds, :]
+    flags = full_uvh5.flag_array[:, :, freq_inds, :]
+    nsamples = full_uvh5.nsample_array[:, :, freq_inds, :]
+    partial_uvh5.write_uvh5_part(partial_testfile, data, flags, nsamples,
+                                 freq_chans=freq_inds)
+
+    # also write the arrays to the partial object
+    partial_uvh5.data_array[:, :, freq_inds, :] = data
+    partial_uvh5.flag_array[:, :, freq_inds, :] = flags
+    partial_uvh5.nsample_array[:, :, freq_inds, :] = nsamples
+
+    # read in the file and make sure it matches
+    partial_uvh5_file = UVData()
+    partial_uvh5_file.read_uvh5(partial_testfile)
+    nt.assert_equal(partial_uvh5_file, partial_uvh5)
+
     # do it again, with a single polarization
     # reinitialize
     partial_uvh5 = copy.deepcopy(full_uvh5)
@@ -442,7 +476,7 @@ def test_UVH5PartialWriteIrregular():
     partial_uvh5.flag_array = np.zeros_like(full_uvh5.flag_array, dtype=np.bool)
     partial_uvh5.nsample_array = np.zeros_like(full_uvh5.nsample_array, dtype=np.float32)
 
-    # write a single blt to file
+    # write a single pol to file
     pol_inds = np.arange(1)
     data = full_uvh5.data_array[:, :, :, pol_inds]
     flags = full_uvh5.flag_array[:, :, :, pol_inds]

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1767,13 +1767,55 @@ class UVData(UVBase):
                                 clobber=clobber, no_antnums=no_antnums)
         del(miriad_obj)
 
-    def read_uvh5(self, filename, run_check=True, check_extra=True,
-                  run_check_acceptability=True):
+    def read_uvh5(self, filename, antenna_nums=None, antenna_names=None,
+                  ant_str=None, bls=None, frequencies=None, freq_chans=None,
+                  times=None, polarizations=None, blt_inds=None, read_data=True,
+                  run_check=True, check_extra=True, run_check_acceptability=True):
         """
         Read a UVH5 file.
 
         Args:
             filename: The UVH5 file to read.
+            antenna_nums: The antennas numbers to include when reading data into
+                the object (antenna positions and names for the excluded antennas
+                will be retained). This cannot be provided if antenna_names is
+                also provided. Ignored if read_data is False.
+            antenna_names: The antennas names to include when reading data into
+                the object (antenna positions and names for the excluded antennas
+                will be retained). This cannot be provided if antenna_nums is
+                also provided. Ignored if read_data is False.
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to keep in the object. For length-2 tuples, the  ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are provided,
+                the polarizations argument below must be None. Ignored if read_data is False.
+            ant_str: A string containing information about what antenna numbers
+                and polarizations to include when reading data into the object.
+                Can be 'auto', 'cross', 'all', or combinations of antenna numbers
+                and polarizations (e.g. '1', '1_2', '1x_2y').
+                See tutorial for more examples of valid strings and
+                the behavior of different forms for ant_str.
+                If '1x_2y,2y_3y' is passed, both polarizations 'xy' and 'yy' will
+                be kept for both baselines (1,2) and (2,3) to return a valid
+                pyuvdata object.
+                An ant_str cannot be passed in addition to any of the above antenna
+                args or the polarizations arg.
+                Ignored if read_data is False.
+            frequencies: The frequencies to include when reading data into the
+                object.  Ignored if read_data is False.
+            freq_chans: The frequency channel numbers to include when reading
+                data into the object. Ignored if read_data is False.
+            times: The times to include when reading data into the object.
+                Ignored if read_data is False.
+            polarizations: The polarizations to include when reading data into
+                the object.  Ignored if read_data is False.
+            blt_inds: The baseline-time indices to include when reading data into
+                the object. This is not commonly used. Ignored if read_data is False.
+            read_data: Read in the visibility and flag data. If set to false,
+                only the basic header info and metadata (if read_metadata is True)
+                will be read in. Results in an incompletely defined object
+                (check will not pass). Default True.
             run_check: Option to check for the existence and proper shapes of
                 parameters after reading in the file. Default is True.
             check_extra: Option to check optional parameters as well as required
@@ -1786,18 +1828,35 @@ class UVData(UVBase):
         """
         from . import uvh5
         if isinstance(filename, (list, tuple)):
-            self.read_uvh5(filename[0], run_check=run_check, check_extra=check_extra,
+            if not read_data:
+                raise ValueError('read_data cannot be False for a list of uvfits files')
+
+            self.read_uvh5(filename[0], antenna_nums=antenna_nums,
+                           antenna_names=antenna_names, ant_str=ant_str, bls=bls,
+                           frequencies=frequencies, freq_chans=freq_chans, times=times,
+                           polarizations=polarizations, blt_inds=blt_inds,
+                           read_data=read_data, run_check=run_check,
+                           check_extra=check_extra,
                            run_check_acceptability=run_check_acceptability)
             if len(filename) > 1:
                 for f in filename[1:]:
                     uv2 = UVData()
-                    uv2.read_uvh5(f, run_check=run_check, check_extra=check_extra,
+                    uv2.read_uvh5(f, antenna_nums=antenna_nums,
+                                  antenna_names=antenna_names, ant_str=ant_str, bls=bls,
+                                  frequencies=frequencies, freq_chans=freq_chans,
+                                  times=times, polarizations=polarizations,
+                                  blt_inds=blt_inds, read_data=read_data,
+                                  run_check=run_check, check_extra=check_extra,
                                   run_check_acceptability=run_check_acceptability)
                     self += uv2
                 del(uv2)
         else:
             uvh5_obj = uvh5.UVH5()
-            uvh5_obj.read_uvh5(filename, run_check=run_check, check_extra=check_extra,
+            uvh5_obj.read_uvh5(filename, antenna_nums=antenna_nums,
+                               antenna_names=antenna_names, ant_str=ant_str, bls=bls,
+                               frequencies=frequencies, freq_chans=freq_chans, times=times,
+                               polarizations=polarizations, blt_inds=blt_inds,
+                               read_data=read_data, run_check=run_check, check_extra=check_extra,
                                run_check_acceptability=run_check_acceptability)
             self._convert_from_filetype(uvh5_obj)
             del(uvh5_obj)

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1866,7 +1866,7 @@ class UVData(UVBase):
                    data_compression=None, flags_compression="lzf",
                    nsample_compression="lzf"):
         """
-        Write a UVData object to a UVH5 file.
+        Write a completely in-memory UVData object to a UVH5 file.
 
         Args:
             filename: The UVH5 file to write to.
@@ -1894,6 +1894,102 @@ class UVData(UVBase):
                             clobber=clobber, data_compression=data_compression,
                             flags_compression=flags_compression,
                             nsample_compression=nsample_compression)
+        del(uvh5_obj)
+
+    def initialize_uvh5_file(self, filename, clobber=False, data_compression=None,
+                             flags_compression="lzf", nsample_compression="lzf"):
+        """
+        Initialize a UVH5 file on disk with the header metadata and empty data arrays.
+
+        Args:
+            filename: The UVH5 file to write to.
+            clobber: Option to overwrite the file if it already exists. Default is False.
+            data_compression: HDF5 filter to apply when writing the data_array. Default is
+                None (no filter/compression).
+            flags_compression: HDF5 filter to apply when writing the flags_array. Default is
+                the LZF filter.
+            nsample_compression: HDF5 filter to apply when writing the nsample_array. Default is
+                the LZF filter.
+
+        Returns:
+            None
+
+        Notes:
+            When partially writing out data, this function should be called first to initialize the
+            file on disk. The data is then actually written by calling the write_uvh5_part method,
+            with the same filename as the one specified in this function. See the tutorial for a
+            worked example.
+        """
+        uvh5_obj = self._convert_to_filetype('uvh5')
+        uvh5_obj.initialize_uvh5_file(filename, clobber=clobber,
+                                      data_compression=data_compression,
+                                      flags_compression=flags_compression,
+                                      nsample_compression=nsample_compression)
+        del(uvh5_obj)
+
+    def write_uvh5_part(self, filename, data_array, flags_array, nsample_array, check_header=True,
+                        antenna_nums=None, antenna_names=None, ant_str=None, bls=None,
+                        frequencies=None, freq_chans=None, times=None, polarizations=None,
+                        blt_inds=None):
+        """
+        Write data to a UVH5 file that has already been initialized.
+
+        Args:
+            filename: the file on disk to write data to. It must already exist,
+                and is assumed to have been initialized with initialize_uvh5_file.
+            data_array: the data to write to disk. A check is done to ensure that
+                the dimensions of the data passed in conform to the ones specified by
+                the "selection" arguments.
+            flags_array: the flags array to write to disk. A check is done to ensure
+                that the dimensions of the data passed in conform to the ones specified
+                by the "selection" arguments.
+            nsample_array: the nsample array to write to disk. A check is done to ensure
+                that the dimensions fo the data passed in conform to the ones specified
+                by the "selection" arguments.
+            check_header: option to check that the metadata present in the header
+                on disk matches that in the object. Default is True.
+            antenna_nums: The antennas numbers to include when writing data into
+                the object (antenna positions and names for the excluded antennas
+                will be retained). This cannot be provided if antenna_names is
+                also provided.
+            antenna_names: The antennas names to include when writing data into
+                the object (antenna positions and names for the excluded antennas
+                will be retained). This cannot be provided if antenna_nums is
+                also provided.
+            bls: A list of antenna number tuples (e.g. [(0,1), (3,2)]) or a list of
+                baseline 3-tuples (e.g. [(0,1,'xx'), (2,3,'yy')]) specifying baselines
+                to write to the file. For length-2 tuples, the ordering of the numbers
+                within the tuple does not matter. For length-3 tuples, the polarization
+                string is in the order of the two antennas. If length-3 tuples are provided,
+                the polarizations argument below must be None.
+            ant_str: A string containing information about what antenna numbers
+                and polarizations to include when writing data into the object.
+                Can be 'auto', 'cross', 'all', or combinations of antenna numbers
+                and polarizations (e.g. '1', '1_2', '1x_2y').
+                See tutorial for more examples of valid strings and
+                the behavior of different forms for ant_str.
+                If '1x_2y,2y_3y' is passed, both polarizations 'xy' and 'yy' will
+                be written for both baselines (1,2) and (2,3) to reflect a valid
+                pyuvdata object.
+                An ant_str cannot be passed in addition to any of the above antenna
+                args or the polarizations arg.
+            frequencies: The frequencies to include when writing data to the file.
+            freq_chans: The frequency channel numbers to include when writing data to the file.
+            times: The times to include when writing data to the file.
+            polarizations: The polarizations to include when writing data to the file.
+            blt_inds: The baseline-time indices to include when writing data to the file.
+                This is not commonly used.
+
+        Returns:
+            None
+        """
+        uvh5_obj = self._convert_to_filetype('uvh5')
+        uvh5_obj.write_uvh5_part(filename, data_array, flags_array, nsample_array,
+                                 check_header=check_header, antenna_nums=antenna_nums,
+                                 antenna_names=antenna_names, bls=bls, ant_str=ant_str,
+                                 frequencies=frequencies, freq_chans=freq_chans,
+                                 times=times, polarizations=polarizations,
+                                 blt_inds=blt_inds)
         del(uvh5_obj)
 
     def reorder_pols(self, order=None, run_check=True, check_extra=True,

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -587,7 +587,7 @@ class UVH5(UVData):
             self.nsample_array = None
             replace_nsamples = True
         else:
-            replace_namples = False
+            replace_nsamples = False
 
         if self != uvd_file:
             raise AssertionError("The object metadata in memory and metadata on disk are different")

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -569,10 +569,36 @@ class UVH5(UVData):
             header = f['/Header']
             uvd_file._read_header(header)
 
+        # temporarily remove data, flag, and nsample arrays, so we only check metadata
+        if self.data_array is not None:
+            data_array = self.data_array
+            self.data_array = None
+            replace_data = True
+        else:
+            replace_data = False
+        if self.flag_array is not None:
+            flag_array = self.flag_array
+            self.flag_array = None
+            replace_flags = True
+        else:
+            replace_flags = False
+        if self.nsample_array is not None:
+            nsample_array = self.nsample_array
+            self.nsample_array = None
+            replace_nsamples = True
+        else:
+            replace_namples = False
+
         if self != uvd_file:
             raise AssertionError("The object metadata in memory and metadata on disk are different")
         else:
             # clean up after ourselves
+            if replace_data:
+                self.data_array = data_array
+            if replace_flags:
+                self.flag_array = flag_array
+            if replace_nsamples:
+                self.nsample_array = nsample_array
             del uvd_file
         return
 

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -94,7 +94,7 @@ class UVH5(UVData):
         self.Nants_telescope = int(header['Nants_telescope'].value)
         self.ant_1_array = header['ant_1_array'].value
         self.ant_2_array = header['ant_2_array'].value
-        self.antenna_names = list(header['antenna_names'].value)
+        self.antenna_names = [uvutils.bytes_to_str(n) for n in header['antenna_names'].value]
         self.antenna_numbers = header['antenna_numbers'].value
 
         # get baseline array

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -232,10 +232,9 @@ class UVH5(UVData):
         return
 
     def read_uvh5(self, filename, antenna_nums=None, antenna_names=None,
-                  ant_str=None, bls=None, frequencies=None, freq_channels=None,
+                  ant_str=None, bls=None, frequencies=None, freq_chans=None,
                   times=None, polarizations=None, blt_inds=None, read_data=True,
-                  run_check=True, check_extra=True,
-                  run_check_acceptability=True):
+                  run_check=True, check_extra=True, run_check_acceptability=True):
         """
         Read in data from a UVH5 file.
 
@@ -316,7 +315,7 @@ class UVH5(UVData):
 
             return
 
-    def _write_uvh5_header(self, header):
+    def _write_header(self, header):
         """Internal function to write uvh5 header information.
         """
         # write out telescope and source information
@@ -444,7 +443,7 @@ class UVH5(UVData):
                 raise ValueError("File exists; skipping")
 
         # open file for writing
-        with h5py.open(filename, 'w') as f:
+        with h5py.File(filename, 'w') as f:
             # write header
             header = f.create_group("Header")
             self._write_header(header)
@@ -514,7 +513,7 @@ class UVH5(UVData):
                 raise ValueError("File exists; skipping")
 
         # write header and empty arrays to file
-        with h5py.open(filename, 'w') as f:
+        with h5py.File(filename, 'w') as f:
             # write header
             header = f.create_group("Header")
             self._write_header(header)

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -313,7 +313,7 @@ class UVH5(UVData):
                            bls, frequencies, freq_chans, times, polarizations,
                            blt_inds, run_check, check_extra, run_check_acceptability)
 
-            return
+        return
 
     def _write_header(self, header):
         """Internal function to write uvh5 header information.
@@ -685,7 +685,7 @@ class UVH5(UVData):
 
             # test if frequencies are regularly spaced
             if len(set(np.ediff1d(freq_inds))) <= 1:
-                f_reg_spaced = True
+                freq_reg_spaced = True
                 freq_start = freq_inds[0]
                 freq_end = freq_inds[-1] + 1
                 if len(freq_inds) == 1:
@@ -694,7 +694,7 @@ class UVH5(UVData):
                     d_freq = freq_inds[1] - freq_inds[0]
                 freq_inds = np.s_[freq_start:freq_end:d_freq]
             else:
-                f_reg_spaced = False
+                freq_reg_spaced = False
         else:
             Nfreqs = self.Nfreqs
             freq_reg_spaced = True

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -166,7 +166,7 @@ class UVH5(UVData):
             # no select, read in all the data
             self.data_array = dgrp['visdata'].value
             self.flag_array = dgrp['flags'].value
-            self.nsample_array = dgrp['nsample_array'].value
+            self.nsample_array = dgrp['nsamples'].value
         else:
             # do select operations on everything except data_array, flag_array and nsample_array
             self._select_metadata(blt_inds, freq_inds, pol_inds, history_update_string)
@@ -174,55 +174,55 @@ class UVH5(UVData):
             # open references to datasets
             visdata_dset = dgrp['visdata']
             flags_dset = dgrp['flags']
-            nsample_array_dset = dgrp['nsample_array']
+            nsamples_dset = dgrp['nsamples']
 
             # just read in the right portions of the data and flag arrays
             if blt_frac == min_frac:
                 visdata = visdata_dset[blt_inds, :, :, :]
                 flags = flags_dset[blt_inds, :, :, :]
-                nsample_array = nsample_array_dset[blt_inds, :, :, :]
+                nsamples = nsamples_dset[blt_inds, :, :, :]
 
                 assert(self.Nspws == visdata.shape[1])
 
                 if freq_frac < 1:
                     visdata = visdata[:, :, freq_inds, :]
                     flags = flags[:, :, freq_inds, :]
-                    nsample_array = nsample_array[:, :, freq_inds, :]
+                    nsamples = nsamples[:, :, freq_inds, :]
                 if pol_frac < 1:
                     visdata = visdata[:, :, :, pol_inds]
                     flags = flags[:, :, :, pol_inds]
-                    nsample_array = nsample_array[:, :, :, pol_inds]
+                    nsamples = nsamples[:, :, :, pol_inds]
             elif freq_frac == min_frac:
                 visdata = visdata_dset[:, :, freq_inds, :]
                 flags = flags_dset[:, :, freq_inds, :]
-                nsample_array = nsample_array_dset[:, :, freq_inds, :]
+                nsamples = nsamples_dset[:, :, freq_inds, :]
 
                 if blt_frac < 1:
                     visdata = visdata[blt_inds, :, :, :]
                     flags = flags[blt_inds, :, :, :]
-                    nsample_array = nsample_array[blt_inds, :, :, :]
+                    nsamples = nsamples[blt_inds, :, :, :]
                 if pol_frac < 1:
                     visdata = visdata[:, :, :, pol_inds]
                     flags = flags[:, :, :, pol_inds]
-                    nsample_array = nsample_array[:, :, :, pol_inds]
+                    nsamples = nsamples[:, :, :, pol_inds]
             else:
                 visdata = visdata_dset[:, :, :, pol_inds]
                 flags = flags_dset[:, :, :, pol_inds]
-                nsample_array = nsample_array_dset[:, :, :, pol_inds]
+                nsamples = nsamples_dset[:, :, :, pol_inds]
 
                 if blt_frac < 1:
                     visdata = visdata[blt_inds, :, :, :]
                     flags = flags[blt_inds, :, :, :]
-                    nsample_array = nsample_array[blt_inds, :, :, :]
+                    nsamples = nsamples[blt_inds, :, :, :]
                 if freq_frac < 1:
                     visdata = visdata[:, :, freq_inds, :]
                     flags = flags[:, :, freq_inds, :]
-                    nsample_array = nsample_array[:, :, freq_inds, :]
+                    nsamples = nsamples[:, :, freq_inds, :]
 
             # save arrays in object
             self.data_array = visdata
             self.flag_array = flags
-            self.nsample_array = nsample_array
+            self.nsample_array = nsamples
 
         # check if object has all required UVParameters set
         if run_check:
@@ -465,11 +465,11 @@ class UVH5(UVData):
                 flags = dgrp.create_dataset("flags", chunks=True,
                                             data=self.flag_array)
             if nsample_compression is not None:
-                nsample_array = dgrp.create_dataset("nsample_array", chunks=True,
+                nsample_array = dgrp.create_dataset("nsamples", chunks=True,
                                                     data=self.nsample_array.astype(np.float32),
                                                     compression=nsample_compression)
             else:
-                nsample_array = dgrp.create_dataset("nsample_array", chunks=True,
+                nsample_array = dgrp.create_dataset("nsamples", chunks=True,
                                                     data=self.nsample_array.astype(np.float32))
 
         return
@@ -539,10 +539,10 @@ class UVH5(UVData):
                 flags = dgrp.create_dataset("flags", data_size, chunks=True,
                                             dtype='b1')
             if nsample_compression is not None:
-                nsample_array = dgrp.create_dataset("nsample_array", data_size, chunks=True,
+                nsample_array = dgrp.create_dataset("nsamples", data_size, chunks=True,
                                                     dtype='f4', compression=nsample_compression)
             else:
-                nsample_array = dgrp.create_dataset("nsample_array", data_size, chunks=True,
+                nsample_array = dgrp.create_dataset("nsamples", data_size, chunks=True,
                                                     dtype='f4')
 
         return
@@ -730,7 +730,7 @@ class UVH5(UVData):
             dgrp = f['/Data']
             visdata_dset = dgrp['visdata']
             flags_dset = dgrp['flags']
-            nsample_array_dset = dgrp['nsample_array']
+            nsamples_dset = dgrp['nsamples']
 
             # check if we can do fancy indexing
             # as long as at least 2 out of 3 axes can be written as slices, we can be fancy
@@ -738,7 +738,7 @@ class UVH5(UVData):
             if n_reg_spaced >= 2:
                 visdata_dset[blt_inds, :, freq_inds, pol_inds] = data_array
                 flags_dset[blt_inds, :, freq_inds, pol_inds] = flags_array
-                nsample_array_dset[blt_inds, :, freq_inds, pol_inds] = nsample_array
+                nsamples_dset[blt_inds, :, freq_inds, pol_inds] = nsample_array
             elif n_reg_spaced == 1:
                 # figure out which axis is regularly spaced
                 if blt_reg_spaced:
@@ -746,19 +746,19 @@ class UVH5(UVData):
                         for ipol, pol_idx in enumerate(pol_inds):
                             visdata_dset[blt_inds, :, freq_idx, pol_idx] = data_array[:, :, ifreq, ipol]
                             flags_dset[blt_inds, :, freq_idx, pol_idx] = flags_array[:, :, ifreq, ipol]
-                            nsample_array_dset[blt_inds, :, freq_idx, pol_idx] = nsample_array[:, :, ifreq, ipol]
+                            nsamples_dset[blt_inds, :, freq_idx, pol_idx] = nsample_array[:, :, ifreq, ipol]
                 elif freq_reg_spaced:
                     for iblt, blt_idx in enumerate(blt_inds):
                         for ipol, pol_idx in enumerate(pol_inds):
                             visdata_dset[blt_idx, :, freq_inds, pol_idx] = data_array[iblt, :, :, ipol]
                             flags_dset[blt_idx, :, freq_inds, pol_idx] = flags_array[iblt, :, :, ipol]
-                            nsample_array_dset[blt_idx, :, freq_inds, pol_idx] = nsample_array[iblt, :, :, ipol]
+                            nsamples_dset[blt_idx, :, freq_inds, pol_idx] = nsample_array[iblt, :, :, ipol]
                 else:  # pol_reg_spaced
                     for iblt, blt_idx in enumerate(blt_inds):
                         for ifreq, freq_idx in enumerate(freq_inds):
                             visdata_dset[blt_idx, :, freq_idx, pol_inds] = data_array[iblt, :, ifreq, :]
                             flags_dset[blt_idx, :, freq_idx, pol_inds] = flags_array[iblt, :, ifreq, :]
-                            nsample_array_dset[blt_idx, :, freq_idx, pol_inds] = nsample_array[iblt, :, ifreq, :]
+                            nsamples_dset[blt_idx, :, freq_idx, pol_inds] = nsample_array[iblt, :, ifreq, :]
             else:
                 # all axes irregularly spaced
                 # perform a triple loop -- probably very slow!
@@ -767,6 +767,6 @@ class UVH5(UVData):
                         for ipol, pol_idx in enumerate(pol_inds):
                             visdata_dset[blt_idx, :, freq_idx, pol_idx] = data_array[iblt, :, ifreq, ipol]
                             flags_dset[blt_idx, :, freq_idx, pol_idx] = flags_array[iblt, :, ifreq, ipol]
-                            nsample_array_dset[blt_idx, :, freq_idx, pol_idx] = nsample_array[iblt, :, ifreq, ipol]
+                            nsamples_dset[blt_idx, :, freq_idx, pol_idx] = nsample_array[iblt, :, ifreq, ipol]
 
         return


### PR DESCRIPTION
This PR adds support for partial reading and partial writing of uvh5 files. The partial reading is very similar to that supported for miriad and uvfits files. The partial writing is new for the HDF5 format, and attempts to write the data to files as efficiently as possible. It also requires first initializing an empty file on disk, and then populating the data in it in pieces.

@bhazelton I'm planning on adding examples of the partial I/O to the tutorial. Let me know if you would like it to be a part of this PR, or I can make an issue and do it at a later date.

Fixes #351.