### PR TITLE
allow read_data = False for single element lists of files in read_uvh5

### DIFF
--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -64,7 +64,7 @@ def test_ReadUVH5Errors():
     uv_in = UVData()
     fake_file = os.path.join(DATA_PATH, 'fake_file.hdf5')
     nt.assert_raises(IOError, uv_in.read_uvh5, fake_file)
-    nt.assert_raises(ValueError, uv_in.read_uvh5, ['list of','fake files'], read_data=False)
+    nt.assert_raises(ValueError, uv_in.read_uvh5, ['list of', 'fake files'], read_data=False)
 
     return
 

--- a/pyuvdata/tests/test_uvh5.py
+++ b/pyuvdata/tests/test_uvh5.py
@@ -64,6 +64,7 @@ def test_ReadUVH5Errors():
     uv_in = UVData()
     fake_file = os.path.join(DATA_PATH, 'fake_file.hdf5')
     nt.assert_raises(IOError, uv_in.read_uvh5, fake_file)
+    nt.assert_raises(ValueError, uv_in.read_uvh5, ['list of','fake files'], read_data=False)
 
     return
 

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -1871,7 +1871,7 @@ class UVData(UVBase):
         """
         from . import uvh5
         if isinstance(filename, (list, tuple)):
-            if not read_data:
+            if not read_data and len(filename) > 1:
                 raise ValueError('read_data cannot be False for a list of uvfits files')
 
             self.read_uvh5(filename[0], antenna_nums=antenna_nums,


### PR DESCRIPTION
Often, it's easier to keep files to load in lists, even if they're length one. This slightly relaxes the requirement that you can't run lists of paths through read_uvh5 with read_data = False without needing to dive into the whole rabbit hole that is adding metadata-only uvdata objects.