### PR TITLE
changed uvdata._uvw_array.acceptable_range to (0, 1e8)

### DIFF
--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1199,6 +1199,7 @@ def test_add():
     uv2 = uv_cross + uv_auto
     nt.assert_equal(uv2.Nbls, uv_auto.Nbls + uv_cross.Nbls)
 
+
 def test_add_drift():
     uv_full = UVData()
     testfile = os.path.join(

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -217,6 +217,22 @@ class TestUVDataBasicMethods(object):
                                                 == self.uv_object.ant_2_array)[0])
         nt.assert_true(self.uv_object.check())
 
+        # test auto and cross corr uvw_array
+        uvd = UVData()
+        uvd.read_miriad(os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA"))
+        autos = np.isclose(uvd.ant_1_array - uvd.ant_2_array, 0.0)
+        auto_inds = np.where(autos)[0]
+        cross_inds = np.where(~autos)[0]
+
+        # make auto have non-zero uvw coords, assert ValueError
+        uvd.uvw_array[auto_inds[0], 0] = 0.1
+        nt.assert_raises(ValueError, uvd.check)
+
+        # make cross have |uvw| zero, assert ValueError
+        uvd.read_miriad(os.path.join(DATA_PATH, "zen.2457698.40355.xx.HH.uvcA"))
+        uvd.uvw_array[cross_inds[0]][:] = 0.0
+        nt.assert_raises(ValueError, uvd.check)
+
     def test_nants_data_telescope(self):
         self.uv_object.Nants_data = self.uv_object.Nants_telescope - 1
         nt.assert_true(self.uv_object.check)

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -1051,6 +1051,7 @@ def test_add():
     ants1 = ants[0:6]
     ants2 = ants[6:12]
     ants3 = ants[12:]
+
     # All blts where ant_1 is in list
     ind1 = [i for i in range(uv1.Nblts) if uv1.ant_1_array[i] in ants1]
     ind2 = [i for i in range(uv2.Nblts) if uv2.ant_1_array[i] in ants2]
@@ -1185,6 +1186,18 @@ def test_add():
     uv1.history = uv_full.history
     nt.assert_equal(uv1, uv_full)
 
+    # test add of autocorr-only and crosscorr-only objects
+    uv_full = UVData()
+    uv_full.read_miriad(os.path.join(DATA_PATH, 'zen.2457698.40355.xx.HH.uvcA'))
+    bls = uv_full.get_antpairs()
+    autos = [bl for bl in bls if bl[0] == bl[1]]
+    cross = sorted(set(bls) - set(autos))
+    uv_auto = uv_full.select(bls=autos, inplace=False)
+    uv_cross = uv_full.select(bls=cross, inplace=False)
+    uv1 = uv_auto + uv_cross
+    nt.assert_equal(uv1.Nbls, uv_auto.Nbls + uv_cross.Nbls)
+    uv2 = uv_cross + uv_auto
+    nt.assert_equal(uv2.Nbls, uv_auto.Nbls + uv_cross.Nbls)
 
 def test_add_drift():
     uv_full = UVData()

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -97,7 +97,7 @@ class UVData(UVBase):
         self._uvw_array = uvp.UVParameter('uvw_array', description=desc,
                                           form=('Nblts', 3),
                                           expected_type=np.float,
-                                          acceptable_range=(1e-3, 1e8), tols=.001)
+                                          acceptable_range=(0.0, 1e8), tols=.001)
 
         desc = ('Array of times, center of integration, shape (Nblts), '
                 'units Julian Date')
@@ -343,10 +343,6 @@ class UVData(UVBase):
                 are acceptable. Default is True.
         """
         # first run the basic check from UVBase
-        if self.ant_1_array is not None and np.all(self.ant_1_array == self.ant_2_array):
-            # Special case of only containing auto correlations, adjust uvw acceptable_range
-            self._uvw_array.acceptable_range = (0.0, 0.0)
-
         # set the phase type based on object's value
         if self.phase_type == 'phased':
             self.set_phased()


### PR DESCRIPTION
Changes default `uvdata._uvw_array.acceptable_range` to `(0, 1e8)` and removes adjustment to `(0.0, 0.0)` in `uvdata.check()` when only autocorrs are present. This addresses the issue relating to concatenating autocorr-only and crosscorr-only `UVData` objects (#396).

Also adds tests in `UVData.check` to test for non-zero uvw coords of autocorrs, and near-zero uvw magnitudes of cross-corrs. Adds appropriate tests in `test_uvdata`.