### PR TITLE
Rationalize coords

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -327,7 +327,7 @@ a) Getting antenna positions in topocentric frame in units of meters
   >>> uvd = UVData()
   >>> uvd.read_miriad('pyuvdata/data/new.uvA')
   >>> antpos = uvd.antenna_positions + uvd.telescope_location # get antennas positions in ECEF
-  >>> antpos = uvutils.ENU_from_ECEF(antpos.T, *uvd.telescope_location_lat_lon_alt).T # convert to topo (ENU) coords.
+  >>> antpos = uvutils.ENU_from_ECEF(antpos, *uvd.telescope_location_lat_lon_alt) # convert to topo (ENU) coords.
 
 
 UVData: Selecting data

--- a/pyuvdata/tests/test_utils.py
+++ b/pyuvdata/tests/test_utils.py
@@ -54,6 +54,11 @@ def test_LatLonAlt_from_XYZ():
     uvtest.checkWarnings(pyuvdata.LatLonAlt_from_XYZ, [xyz_mult.T],
                          message='The expected shape of ECEF xyz array',
                          category=PendingDeprecationWarning)
+    # check warning if  3 x 3 array
+    xyz_3 = np.stack((np.array(ref_xyz), np.array(ref_xyz), np.array(ref_xyz)))
+    uvtest.checkWarnings(pyuvdata.LatLonAlt_from_XYZ, [xyz_3],
+                         message='The xyz array in LatLonAlt_from_XYZ is',
+                         category=PendingDeprecationWarning)
     # check error if only 2 coordinates
     nt.assert_raises(ValueError, pyuvdata.LatLonAlt_from_XYZ, xyz_mult[:, 0:2])
 
@@ -107,6 +112,11 @@ def test_ENU_tofrom_ECEF():
                                                   center_alt],
                          message='The expected shape of ECEF xyz array',
                          category=PendingDeprecationWarning)
+    # check warning if  3 x 3 array
+    uvtest.checkWarnings(pyuvdata.ENU_from_ECEF, [xyz[0:3], center_lat, center_lon,
+                                                  center_alt],
+                         message='The xyz array in ENU_from_ECEF is',
+                         category=PendingDeprecationWarning)
     # check error if only 2 coordinates
     nt.assert_raises(ValueError, pyuvdata.ENU_from_ECEF, xyz[:, 0:2],
                      center_lat, center_lon, center_alt)
@@ -118,6 +128,11 @@ def test_ENU_tofrom_ECEF():
     uvtest.checkWarnings(pyuvdata.ECEF_from_ENU, [enu.T, center_lat, center_lon,
                                                   center_alt],
                          message='The expected shape the ENU array',
+                         category=PendingDeprecationWarning)
+    # check warning if  3 x 3 array
+    uvtest.checkWarnings(pyuvdata.ECEF_from_ENU, [enu[0:3], center_lat, center_lon,
+                                                  center_alt],
+                         message='The enu array in ECEF_from_ENU is',
                          category=PendingDeprecationWarning)
     # check error if only 2 coordinates
     nt.assert_raises(ValueError, pyuvdata.ENU_from_ECEF, enu[:, 0:2], center_lat,

--- a/pyuvdata/tests/test_uvdata.py
+++ b/pyuvdata/tests/test_uvdata.py
@@ -362,8 +362,8 @@ def test_phase_unphaseHERA():
 
     # check that they match if you phase & unphase using antenna locations
     # first replace the uvws with the right values
-    antenna_enu = uvutils.ENU_from_ECEF((UV_raw.antenna_positions + UV_raw.telescope_location).T,
-                                        *UV_raw.telescope_location_lat_lon_alt).T
+    antenna_enu = uvutils.ENU_from_ECEF((UV_raw.antenna_positions + UV_raw.telescope_location),
+                                        *UV_raw.telescope_location_lat_lon_alt)
     uvw_calc = np.zeros_like(UV_raw.uvw_array)
     unique_times, unique_inds = np.unique(UV_raw.time_array, return_index=True)
     for ind, jd in enumerate(unique_times):

--- a/pyuvdata/utils.py
+++ b/pyuvdata/utils.py
@@ -57,6 +57,12 @@ def LatLonAlt_from_XYZ(xyz):
     else:
         xyz_use = xyz
 
+    if xyz.shape == (3, 3):
+        warnings.warn('The xyz array in LatLonAlt_from_XYZ is being '
+                      'interpreted as (Npts, 3). Historically this function '
+                      'has supported (3, Npts) arrays, please verify that '
+                      'array ordering is as expected.', PendingDeprecationWarning)
+
     if xyz_use.ndim == 1:
         xyz_use = xyz_use[np.newaxis, :]
 
@@ -186,6 +192,12 @@ def ENU_from_ECEF(xyz, latitude, longitude, altitude):
         xyz_in = xyz
         transpose = False
 
+    if xyz.shape == (3, 3):
+        warnings.warn('The xyz array in ENU_from_ECEF is being '
+                      'interpreted as (Npts, 3). Historically this function '
+                      'has supported (3, Npts) arrays, please verify that '
+                      'array ordering is as expected.', PendingDeprecationWarning)
+
     if xyz_in.ndim == 1:
         xyz_in = xyz_in[np.newaxis, :]
 
@@ -247,6 +259,12 @@ def ECEF_from_ENU(enu, latitude, longitude, altitude):
     else:
         enu_use = enu
         transpose = False
+
+    if enu.shape == (3, 3):
+        warnings.warn('The enu array in ECEF_from_ENU is being '
+                      'interpreted as (Npts, 3). Historically this function '
+                      'has supported (3, Npts) arrays, please verify that '
+                      'array ordering is as expected.', PendingDeprecationWarning)
 
     if enu_use.ndim == 1:
         enu_use = enu_use[np.newaxis, :]

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -646,8 +646,8 @@ class UVData(UVBase):
                 itrs_uvw_coord = frame_uvw_coord.transform_to('itrs')
 
                 # now convert them to ENU, which is the space uvws are in
-                self.uvw_array[inds, :] = uvutils.ENU_from_ECEF(itrs_uvw_coord.cartesian.get_xyz().value,
-                                                                *itrs_lat_lon_alt).T
+                self.uvw_array[inds, :] = uvutils.ENU_from_ECEF(itrs_uvw_coord.cartesian.get_xyz().value.T,
+                                                                *itrs_lat_lon_alt)
 
         # remove phase center
         self.phase_center_frame = None
@@ -765,7 +765,7 @@ class UVData(UVBase):
                 # convert them to ECEF to transform between frames
                 uvws_use = self.uvw_array[inds, :]
 
-                uvw_ecef = uvutils.ECEF_from_ENU(uvws_use.T, *itrs_lat_lon_alt).T
+                uvw_ecef = uvutils.ECEF_from_ENU(uvws_use, *itrs_lat_lon_alt)
 
                 itrs_uvw_coord = SkyCoord(x=uvw_ecef[:, 0] * units.m,
                                           y=uvw_ecef[:, 1] * units.m,
@@ -2174,7 +2174,8 @@ class UVData(UVBase):
         antpos : ndarray, antenna positions in TOPO frame and units of meters, shape=(Nants, 3)
         ants : ndarray, antenna numbers matching ordering of antpos, shape=(Nants,)
         """
-        antpos = uvutils.ENU_from_ECEF((self.antenna_positions + self.telescope_location).T, *self.telescope_location_lat_lon_alt).T
+        antpos = uvutils.ENU_from_ECEF((self.antenna_positions + self.telescope_location),
+                                       *self.telescope_location_lat_lon_alt)
         ants = self.antenna_numbers
 
         if pick_data_ants:

--- a/pyuvdata/uvdata.py
+++ b/pyuvdata/uvdata.py
@@ -877,18 +877,15 @@ class UVData(UVBase):
                                  'allow_phasing=True.'
                                  )
         antenna_locs_ENU = uvutils.ENU_from_ECEF(
-            (self.antenna_positions + self.telescope_location).T,
-            *self.telescope_location_lat_lon_alt
-        ).T
+            (self.antenna_positions + self.telescope_location),
+            *self.telescope_location_lat_lon_alt)
         uvw_array = np.zeros((self.baseline_array.size, 3))
         for baseline in list(set(self.baseline_array)):
             baseline_inds = np.where(self.baseline_array == baseline)[0]
-            ant1_index = np.where(
-                self.antenna_numbers == self.ant_1_array[baseline_inds[0]]
-            )[0][0]
-            ant2_index = np.where(
-                self.antenna_numbers == self.ant_2_array[baseline_inds[0]]
-            )[0][0]
+            ant1_index = np.where(self.antenna_numbers
+                                  == self.ant_1_array[baseline_inds[0]])[0][0]
+            ant2_index = np.where(self.antenna_numbers
+                                  == self.ant_2_array[baseline_inds[0]])[0][0]
             uvw_array[baseline_inds, :] = (antenna_locs_ENU[ant2_index, :]
                                            - antenna_locs_ENU[ant1_index, :])
         self.uvw_array = uvw_array

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -94,7 +94,7 @@ class UVH5(UVData):
         self.Nants_telescope = int(header['Nants_telescope'].value)
         self.ant_1_array = header['ant_1_array'].value
         self.ant_2_array = header['ant_2_array'].value
-        self.antenna_names = [uvutils._bytes_to_str(n) for n in header['antenna_names'].value]
+        self.antenna_names = [uvutils.bytes_to_str(n) for n in header['antenna_names'].value]
         self.antenna_numbers = header['antenna_numbers'].value
 
         # get baseline array
@@ -335,7 +335,7 @@ class UVH5(UVData):
         header['Npols'] = self.Npols
         header['Nspws'] = self.Nspws
         header['Ntimes'] = self.Ntimes
-        header['antenna_names'] = [uvutils._str_to_bytes(n) for n in self.antenna_names]
+        header['antenna_names'] = [uvutils.str_to_bytes(n) for n in self.antenna_names]
         header['antenna_numbers'] = self.antenna_numbers
         header['uvw_array'] = self.uvw_array
         header['vis_units'] = self.vis_units

--- a/pyuvdata/uvh5.py
+++ b/pyuvdata/uvh5.py
@@ -94,7 +94,7 @@ class UVH5(UVData):
         self.Nants_telescope = int(header['Nants_telescope'].value)
         self.ant_1_array = header['ant_1_array'].value
         self.ant_2_array = header['ant_2_array'].value
-        self.antenna_names = [uvutils.bytes_to_str(n) for n in header['antenna_names'].value]
+        self.antenna_names = [uvutils._bytes_to_str(n) for n in header['antenna_names'].value]
         self.antenna_numbers = header['antenna_numbers'].value
 
         # get baseline array
@@ -335,7 +335,7 @@ class UVH5(UVData):
         header['Npols'] = self.Npols
         header['Nspws'] = self.Nspws
         header['Ntimes'] = self.Ntimes
-        header['antenna_names'] = [uvutils.str_to_bytes(n) for n in self.antenna_names]
+        header['antenna_names'] = [uvutils._str_to_bytes(n) for n in self.antenna_names]
         header['antenna_numbers'] = self.antenna_numbers
         header['uvw_array'] = self.uvw_array
         header['vis_units'] = self.vis_units


### PR DESCRIPTION
Make all coordinate conversions use same axes order, add future deprecation warnings for old ordering.

fixes #402 